### PR TITLE
pathology: make the scan table columns informative

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A curated catalogue of biomedical artificial intelligence models and systems pub
 
 | Domain | Scope | Maintainer | Summary |
 | --- | --- | --- | ---: |
-| [Pathology](pathology.md) | Histopathology, whole-slide imaging and computational pathology | [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/leoyin1127)) | — |
+| [Pathology](pathology.md) | Histopathology, whole-slide imaging and computational pathology | [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/1nslyn)) | — |
 | [Radiology](radiology.md) | CT, MRI, PET, X-ray and fMRI | @Judy Lyu @ Sumin Kim |  |
 | [Biomedical Images — Other](biomedical_images.md) | Ultrasound, microscopy images, retinal imaging, OCT, dermatology, endoscopy and other imaging | @Terry Fu @Zaiyou He |  |
 | [Longitudinal Health Data](longitudinal.md) | Longitudinal EHR, physiological signals, wearables and temporal clinical records | @Evan Su |  |

--- a/pathology.md
+++ b/pathology.md
@@ -1,12 +1,12 @@
 <!-- GENERATED FILE - DO NOT EDIT BY HAND -->
-<!-- Generated from data/pathology.yaml in https://github.com/leoyin1127/biomedical-ai-pipeline -->
+<!-- Generated from data/pathology.yaml in https://github.com/1nslyn/biomedical-ai-pipeline -->
 <!-- Edits made here are overwritten by the next build. -->
 
 # Pathology
 
 Histopathology, whole-slide imaging and computational pathology.
 
-**Maintainer:** [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/leoyin1127))
+**Maintainer:** [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/1nslyn))
 
 **15 entries** · [Back to index](README.md)
 
@@ -487,4 +487,4 @@ Click a model to expand its record.
 
 ---
 
-This page is generated. Add a paper by editing [`data/pathology.yaml`](https://github.com/leoyin1127/biomedical-ai-pipeline/blob/main/data/pathology.yaml) in the [pipeline repository](https://github.com/leoyin1127/biomedical-ai-pipeline) and rebuilding — edits made here are overwritten. The schema and house rules are in [CONTRIBUTING.md](https://github.com/leoyin1127/biomedical-ai-pipeline/blob/main/CONTRIBUTING.md).
+This page is generated. Add a paper by editing [`data/pathology.yaml`](https://github.com/1nslyn/biomedical-ai-pipeline/blob/main/data/pathology.yaml) in the [pipeline repository](https://github.com/1nslyn/biomedical-ai-pipeline) and rebuilding — edits made here are overwritten. The schema and house rules are in [CONTRIBUTING.md](https://github.com/1nslyn/biomedical-ai-pipeline/blob/main/CONTRIBUTING.md).

--- a/pathology.md
+++ b/pathology.md
@@ -10,23 +10,25 @@ Histopathology, whole-slide imaging and computational pathology.
 
 **15 entries** · [Back to index](README.md)
 
-| Date | Model | Venue | Model size | Training data | Pre-training | Downstream tasks |
+| Date | Model | Venue | Model size | Training slides | Pre-training | Downstream tasks |
 | --- | --- | --- | --- | --- | --- | --- |
-| 2026-07 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.4M WSI | contrastive, next-token prediction | detection, subtyping, grading +4 |
-| 2026-04 | [PRET](#model-pret-202604) | Nat. Cancer | — | 4.5K WSI (eval) | DINO, self-supervised | detection, subtyping, segmentation +1 |
-| 2026-03 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | — | 8.2K patients | self-supervised, weakly supervised | biomarker prediction, mutation prediction, benchmarking |
-| 2026-02 | [Neuropath-AI](#model-neuropath-ai-202602) | Lancet Oncol. | — | 5.8K training samples | self-supervised | classification, mutation prediction, gene expression prediction |
-| 2026-02 | [KEEP](#model-keep-202602) | Cancer Cell | 414M | 143K groups | contrastive | segmentation, detection, subtyping +2 |
-| 2026-02 | [CHAI](#model-chai-202602) | J. Clin. Oncol. | — | 477 patients | supervised | biomarker prediction, treatment response |
-| 2025-11 | [TITAN](#model-titan-202511) | Nat. Med. | 48.5M | 335.6K WSI | self-supervised, iBOT, CoCa +1 | classification, subtyping, retrieval +2 |
-| 2025-11 | [SMMILe](#model-smmile-202511) | Nat. Cancer | 1.2M | 3.9K WSI | weakly supervised | classification, detection, subtyping +1 |
-| 2025-01 | [MUSK](#model-musk-202501) | Nature | 675M | 33K WSI | MIM, contrastive | retrieval, visual question answering, classification +4 |
-| 2024-09 | [CHIEF](#model-chief-202409) | Nature | — | 60.5K WSI | self-supervised, weakly supervised | classification, detection, subtyping +2 |
-| 2024-07 | [Virchow](#model-virchow-202407) | Nat. Med. | 632M | 1.5M WSI | DINOv2 | detection, biomarker prediction, classification |
-| 2024-05 | [Prov-GigaPath](#model-prov-gigapath-202405) | Nature | 1B | 171.2K WSI | DINOv2, MAE | classification, subtyping, mutation prediction +1 |
-| 2024-03 | [UNI](#model-uni-202403) | Nat. Med. | 307M | 100.4K WSI | DINOv2 | segmentation, detection, grading +3 |
-| 2024-03 | [CONCH](#model-conch-202403) | Nat. Med. | — | 1.2M pairs | iBOT, CoCa | classification, retrieval, segmentation +1 |
-| 2023-08 | [PLIP](#model-plip-202308) | Nat. Med. | — | 208.4K pairs | CLIP, contrastive | classification, retrieval |
+| 2026.07 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.35M | contrastive → dialogue next-token | detection, subtyping, grading +4 |
+| 2026.04 | [PRET](#model-pret-202604) | Nat. Cancer | _not published_ | none (training-free) | DINO ViT-S/8 encoder, then frozen | detection, subtyping, segmentation +1 |
+| 2026.03 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | _n/a_ | not stated (8.2K patients) | frozen CTransPath + CLAM/SlideGraph | biomarker prediction, mutation prediction, benchmarking |
+| 2026.02 | [Neuropath-AI](#model-neuropath-ai-202602) | Lancet Oncol. | _not published_ | 5.8K samples (not slides) | WSI → molecular inference → hierarchy | classification, mutation prediction, gene expression prediction |
+| 2026.02 | [KEEP](#model-keep-202602) | Cancer Cell | 414M | none (tile–text pairs) | knowledge-graph metric + contrastive | segmentation, detection, subtyping +2 |
+| 2026.02 | [CHAI](#model-chai-202602) | J. Clin. Oncol. | _not published_ | not stated (178 patients) | supervised histomorphologic screening | biomarker prediction, treatment response |
+| 2025.11 | [TITAN](#model-titan-202511) | Nat. Med. | 48.5M (slide enc.) | 336K | iBOT → CoCa (3 stages) | classification, subtyping, retrieval +2 |
+| 2025.11 | [SMMILe](#model-smmile-202511) | Nat. Cancer | 1.2M (MIL head) | 3.9K (cross-validated) | weakly supervised MIL, frozen encoder | classification, detection, subtyping +1 |
+| 2025.01 | [MUSK](#model-musk-202501) | Nature | 675M | 33K | BEiT-3 MIM → contrastive | retrieval, visual question answering, classification +4 |
+| 2024.09 | [CHIEF](#model-chief-202409) | Nature | _not published_ | 60.5K | CTransPath tiles → weakly supervised | classification, detection, subtyping +2 |
+| 2024.07 | [Virchow](#model-virchow-202407) | Nat. Med. | 632M | 1.5M | DINOv2 | detection, biomarker prediction, classification |
+| 2024.05 | [Prov-GigaPath](#model-prov-gigapath-202405) | Nature | 1B (tile enc.) | 171K | DINOv2 tiles → LongNet MAE slides | classification, subtyping, mutation prediction +1 |
+| 2024.03 | [UNI](#model-uni-202403) | Nat. Med. | 307M | 100K | DINOv2 | segmentation, detection, grading +3 |
+| 2024.03 | [CONCH](#model-conch-202403) | Nat. Med. | _not published_ | none (1.17M image–caption) | iBOT → CoCa | classification, retrieval, segmentation +1 |
+| 2023.08 | [PLIP](#model-plip-202308) | Nat. Med. | _not published_ | none (208K image–text) | CLIP contrastive fine-tune | classification, retrieval |
+
+<sub><b>Model size</b> is the count the authors publish, with the component it covers in brackets — a slide encoder and a tile encoder are not comparable. <i>not published</i> means the access routes were worked and no author source states one; <i>n/a</i> means the paper does not introduce a model. <b>Training slides</b> counts whole slides used for training, so a model trained on tiles or image–text pairs shows what it used instead.</sub>
 
 ## Details
 


### PR DESCRIPTION
Follow-up to #3. Same fifteen entries, same layout — three columns of the scan table were rendering values that did not distinguish the rows they sat in, and one of them was wrong.

Two commits: the table change (`pathology.md` only), and a one-line account rename fix described at the bottom.

## Pre-training: name the recipe, not the paradigm

`self-supervised` was the value on nearly every row. It is accurate and it tells a reader nothing — it is the answer for Virchow, UNI, TITAN, CHIEF, PRET and Neuropath-AI alike.

The column now names the method:

| | Was | Now |
| --- | --- | --- |
| Virchow, UNI | `DINOv2` | `DINOv2` |
| TITAN | `self-supervised, iBOT, CoCa +1` | `iBOT → CoCa (3 stages)` |
| MUSK | `MIM, contrastive` | `BEiT-3 MIM → contrastive` |
| Prov-GigaPath | `DINOv2, MAE` | `DINOv2 tiles → LongNet MAE slides` |
| PRISM2 | `contrastive, next-token prediction` | `contrastive → dialogue next-token` |
| Neuropath-AI | `self-supervised` | `WSI → molecular inference → hierarchy` |
| CHIEF | `self-supervised, weakly supervised` | `CTransPath tiles → weakly supervised` |
| HistBiases | `self-supervised, weakly supervised` | `frozen CTransPath + CLAM/SlideGraph` |

The `pretraining` vocabulary stays as it is. It is built for filtering, so coarse buckets are correct there; they just should not have been the column.

## Model size: say what the count covers, and why it is missing

Seven of fifteen cells were a bare em dash, which reads as *nobody looked*. For six of them the access routes were worked and the authors publish no count; the seventh is a benchmarking study with no model to count. Those are different facts and the table now says which:

- **_not published_** — routes worked, no author source states one (PRET, Neuropath-AI, CHAI, CHIEF, CONCH, PLIP)
- **_n/a_** — the paper introduces no model (HistBiases)

The eight real counts now carry their scope where it matters. `48.5M` next to `632M` reads as a 13× difference; it is a slide encoder next to a tile encoder:

| | Was | Now |
| --- | --- | --- |
| TITAN | `48.5M` | `48.5M (slide enc.)` |
| SMMILe | `1.2M` | `1.2M (MIL head)` |
| Prov-GigaPath | `1B` | `1B (tile enc.)` |

## Training slides: the previous column printed evaluation sets as training data

This is the one that was actually wrong. The column picked a number out of `data.scale` by key priority, and `data.scale` counts different things in different records. PRET is training-free and its 4,484 slides are its benchmark; SMMILe's 3,850 slides are the whole cross-validated evaluation. Both rendered as though they were training corpora.

The count is now written per entry and says what it is:

| | Was | Now |
| --- | --- | --- |
| PRET | `4.5K WSI (eval)` | `none (training-free)` |
| SMMILe | `3.9K WSI` | `3.9K (cross-validated)` |
| KEEP | `143K groups` | `none (tile–text pairs)` |
| CONCH | `1.2M pairs` | `none (1.17M image–caption)` |
| Neuropath-AI | `5.8K training samples` | `5.8K samples (not slides)` |
| HistBiases | `8.2K patients` | `not stated (8.2K patients)` |
| CHAI | `477 patients` | `not stated (178 patients)` |
| Virchow, TITAN, UNI | `1.5M WSI`, `335.6K WSI`, `100.4K WSI` | `1.5M`, `336K`, `100K` |

CHAI is worth calling out: 477 is the full cohort, but 178 of those are the development set and 299 are validation. The old column labelled the whole cohort as training data.

## Dates

`2026-07` → `2026.07`. The hyphen is a line-break opportunity, so the narrowest column was wrapping onto two lines.

## Review notes

- The three new fields (`pretraining_short`, `params_scope`, `training_slides`) are **summaries of data already in each record** — the pre-training label condenses `pretraining_detail`, the slide count comes from `data.scale`. **No sourced value was edited and no new claim about any paper is introduced**; where a cell shows a different number than before, it is a different field of the same record (CHAI's development cohort rather than its full cohort), not a revised figure.
- `validate.py` enforces the invariants: `params_status` is required exactly when `params` is null, rejected when it is not; `params_scope` is rejected on an empty count; each cell has a length limit so the table cannot silently start wrapping again. All five rules are exercised.
- A legend under the table explains *not published* / *n/a* and the scope brackets, and only renders on pages that use them.
- Field reference and house rules updated in [CONTRIBUTING.md](https://github.com/1nslyn/biomedical-ai-pipeline/blob/main/CONTRIBUTING.md), and the shared `add-paper.md` prompt now requires these fields, so the next entry cannot render blanks. Two stale claims in CONTRIBUTING about `verify` notes rendering on the page were corrected while there.

## Second commit: account rename

`leoyin1127` renamed to `1nslyn`. Every generated page footer and the Pathology maintainer link still pointed at the old name, which resolves today only because GitHub redirects renamed accounts — and that redirect stops the moment anyone registers the old name. This repository is public, so those links would then point at a stranger's repository.

`README.md` changes by exactly one line: the GitHub handle in the Pathology row. Column layout and the other eight rows are byte-identical to main.

---

Generated from `data/pathology.yaml` in [1nslyn/biomedical-ai-pipeline](https://github.com/1nslyn/biomedical-ai-pipeline). `pathology.md` is a build artifact — edits here are overwritten; changes belong in the YAML.
