### PR TITLE
Update radiology page with model sizes and training-data notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A curated catalogue of biomedical artificial intelligence models and systems pub
 | Domain | Scope | Maintainer | Summary |
 | --- | --- | --- | ---: |
 | [Pathology](pathology.md) | Histopathology, whole-slide imaging and computational pathology | [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/leoyin1127)) | — |
-| [Radiology](radiology.md) | CT, MRI, PET, X-ray and fMRI | @Judy Lyu @ Sumin Kim |  |
+| [Radiology](radiology.md) | CT, MRI, PET, X-ray and fMRI | [Judy Lyu](https://github.com/judylyu) @ Sumin Kim |  |
 | [Biomedical Images — Other](biomedical_images.md) | Ultrasound, microscopy images, retinal imaging, OCT, dermatology, endoscopy and other imaging | @Terry Fu @Zaiyou He |  |
 | [Longitudinal Health Data](longitudinal.md) | Longitudinal EHR, physiological signals, wearables and temporal clinical records | @Evan Su |  |
 | [Multimodal AI](multimodal.md) | Cross-modal health models without a single dominant biomedical domain | @Yeonwoo Seo |  |

--- a/radiology.md
+++ b/radiology.md
@@ -8,37 +8,39 @@ CT, MRI, PET, X-ray and fMRI foundation models.
 
 | Date | Model | Venue | Model size | Training data | Pre-training | Downstream tasks |
 | --- | --- | --- | --- | --- | --- | --- |
-| 2026-07 | [NeuroVFM](#model-neurovfm-202607) | Nat. Med. | — | 5.24M volumes | JEPA | classification, report generation, retrieval +2 |
-| 2026-07 | [MARS](#model-mars-202607) | Nat. Biomed. Eng. | — | 336K volumes | MAE, contrastive learning | classification, segmentation, registration +2 |
-| 2026-05 | [MultitaskCognition](#model-multitaskcognition-202605) | Nat. Aging | — | ~3K studies | supervised, transfer learning | classification, segmentation, regression +1 |
-| 2026-04 | [FM-HCT](#model-fm-hct-202604) | Nat. Biomed. Eng. | — | 362K volumes | DINO | classification, retrieval |
-| 2026-04 | [NeuroFM](#model-neurofm-202604) | Nat. Biomed. Eng. | — | 8.65M frames | MAE | regression, classification, prognosis |
-| 2026-03 | [TRIBEv2](#model-tribev2-202603) | arXiv | — | Multiple datasets | Multimodal representation learning | regression |
-| 2026-03 | [Merlin](#model-merlin-202603) | Nature | — | 25.5K CT volumes | CLIP | classification, segmentation, retrieval +2 |
-| 2026-03 | [Thymus-IO](#model-thymus-io-202603) | Nature | — | 5.7K CT volumes | SwAV | classification, prognosis |
-| 2026-03 | [Thymus-Adult](#model-thymus-adult-202603) | Nature | — | 5.7K CT volumes | SwAV | classification |
-| 2026-02 | [OMAFound](#model-omafound-202602) | Nat. Health | — | 325.2K CT volumes | self-supervised | classification |
-| 2026-02 | [CMR Transformer](#model-cmr-transformer-202602) | Nat. Biomed. Eng. | — | ~21K scans | InfoNCE, contrastive | regression, classification |
-| 2026-02 | [BrainIAC](#model-brainiac-202602) | Nat. Neurosci. | — | 32K scans | SimCLR | classification, regression, segmentation +1 |
-| 2026-02 | [CT-CLIP / CT-CHAT](#model-ct-clip-ct-chat-202602) | Nat. Biomed. Eng. | — | 25.7K CT volumes | CLIP | classification, retrieval, VQA |
-| 2026-02 | [PRIMA](#model-prima-202602) | Nat. Biomed. Eng. | — | 221K studies | CLIP | classification, triage, regression |
-| 2026-02 | [MAOSS](#model-maoss-202602) | Nat. Commun. | — | Multisite data + 226 publications | — | classification, prognosis |
-| 2026-01 | [AFLoc](#model-afloc-202601) | Nat. Biomed. Eng. | — | MIMIC-CXR | CLIP | localization, classification |
-| 2026-01 | [deepmriprep](#model-deepmriprep-202601) | Nat. Comput. Sci. | — | 685 MRI scans | — | preprocessing |
-| 2026-01 | [FOMO25](#model-fomo25-202601) | arXiv | — | 176K volumes | MAE | segmentation, classification, regression |
-| 2025-12 | [VoCo](#model-voco-202512) | IEEE TPAMI | — | 160K volumes | VoCo, contrastive learning | segmentation, classification, regression +1 |
-| 2025-12 | [TAP-CT](#model-tap-ct-202512) | arXiv | — | 105K volumes | DINOv2 | segmentation, classification |
-| 2025-12 | [AnyMC3D](#model-anymc3d-202512) | arXiv | — | — | DINOv2, DINOv3 | classification |
-| 2025-11 | [Pillar-0](#model-pillar-0-202511) | arXiv | — | ~155K volumes | contrastive, vision-language | classification, prognosis |
-| 2025-11 | [SPECTRE](#model-spectre-202511) | CVPR 2026 | — | 230K CT volumes | DINOv3, SigLIP | classification, segmentation, retrieval |
-| 2025-10 | [BrainFound](#model-brainfound-202510) | arXiv | — | 10K volumes | DINOv2 | classification |
-| 2025-09 | [MRI-PTPCa](#model-mri-ptpca-202509) | Nat. Cancer | — | — | BYOL | classification, grading |
-| 2025-08 | [Curia](#model-curia-202508) | arXiv | — | 228M DICOM images | DINOv2 | General-purpose multimodal radiology representation learning |
-| 2025-07 | [Percival](#model-percival-202507) | medRxiv | — | 403K CT volumes | InfoNCE, contrastive | retrieval, classification, prognosis |
-| 2025-04 | [Spark3D](#model-spark3d-202504) | CVPR 2025 | — | 44K MRI volumes | MAE | segmentation |
-| 2025-01 | [CT-FM](#model-ct-fm-202501) | arXiv | — | 148K CT volumes | SimCLR | segmentation, triage, retrieval |
-| 2025-01 | [3DINO](#model-3dino-202501) | arXiv | — | 1.3K patients | 3DINO, self-supervised | classification, segmentation |
-| 2024-12 | [BME-X](#model-bme-x-202412) | Nat. Biomed. Eng. | — | — | — | segmentation, registration, classification |
+| 2026.07 | [NeuroVFM](#model-neurovfm-202607) | Nat. Med. | 85.8M | 5.24M volumes | JEPA | classification, report generation, retrieval +2 |
+| 2026.07 | [MARS](#model-mars-202607) | Nat. Biomed. Eng. | _not published_ | 336K volumes | MAE, contrastive learning | classification, segmentation, registration +2 |
+| 2026.05 | [MultitaskCognition](#model-multitaskcognition-202605) | Nat. Aging | _n/a_ | not stated (~3K studies) | supervised, transfer learning | classification, segmentation, regression +1 |
+| 2026.04 | [FM-HCT](#model-fm-hct-202604) | Nat. Biomed. Eng. | 86M (ViT-B) | 362K volumes | DINO | classification, retrieval |
+| 2026.04 | [NeuroFM](#model-neurofm-202604) | Nat. Biomed. Eng. | _not published_ | none (8.65M fMRI frames) | MAE | regression, classification, prognosis |
+| 2026.03 | [TRIBEv2](#model-tribev2-202603) | arXiv | _not published_ | not stated (multimodal) | Multimodal representation learning | regression |
+| 2026.03 | [Merlin](#model-merlin-202603) | Nature | 121M | none (25.5K volume–report pairs) | CLIP | classification, segmentation, retrieval +2 |
+| 2026.03 | [Thymus-IO](#model-thymus-io-202603) | Nature | _n/a_ | 5.7K CT volumes | SwAV | classification, prognosis |
+| 2026.03 | [Thymus-Adult](#model-thymus-adult-202603) | Nature | _n/a_ | 5.7K CT volumes | SwAV | classification |
+| 2026.02 | [OMAFound](#model-omafound-202602) | Nat. Health | _not published_ | 325.2K CT volumes | self-supervised | classification |
+| 2026.02 | [CMR Transformer](#model-cmr-transformer-202602) | Nat. Biomed. Eng. | _not published_ | none (~21K scan–text pairs) | InfoNCE, contrastive | regression, classification |
+| 2026.02 | [BrainIAC](#model-brainiac-202602) | Nat. Neurosci. | 88.4M | 32K scans | SimCLR | classification, regression, segmentation +1 |
+| 2026.02 | [CT-CLIP / CT-CHAT](#model-ct-clip-ct-chat-202602) | Nat. Biomed. Eng. | _not published_ | none (25.7K volume–text pairs) | CLIP | classification, retrieval, VQA |
+| 2026.02 | [PRIMA](#model-prima-202602) | Nat. Biomed. Eng. | 56.6M (vis. enc.) | none (221K study–report pairs) | CLIP | classification, triage, regression |
+| 2026.02 | [MAOSS](#model-maoss-202602) | Nat. Commun. | _not published_ | not stated (multisite CT + literature) | _n/a_ | classification, prognosis |
+| 2026.01 | [AFLoc](#model-afloc-202601) | Nat. Biomed. Eng. | _not published_ | none (MIMIC-CXR image–text) | CLIP | localization, classification |
+| 2026.01 | [deepmriprep](#model-deepmriprep-202601) | Nat. Comput. Sci. | _n/a_ | not stated (685 MRI scans) | _n/a_ | preprocessing |
+| 2026.01 | [FOMO25](#model-fomo25-202601) | arXiv | _not published_ | 176K volumes | MAE | segmentation, classification, regression |
+| 2025.12 | [VoCo](#model-voco-202512) | IEEE TPAMI | 53M (SwinUNETR-B) | 160K volumes | VoCo, contrastive learning | segmentation, classification, regression +1 |
+| 2025.12 | [TAP-CT](#model-tap-ct-202512) | arXiv | 86M (ViT-B 3D) | 105K volumes | DINOv2 | segmentation, classification |
+| 2025.12 | [AnyMC3D](#model-anymc3d-202512) | arXiv | _n/a_ | none (frozen DINOv2/3) | DINOv2, DINOv3 | classification |
+| 2025.11 | [Pillar-0](#model-pillar-0-202511) | arXiv | 79M (Atlas enc.) | none (~155K volume–report pairs) | contrastive, vision-language | classification, prognosis |
+| 2025.11 | [SPECTRE](#model-spectre-202511) | CVPR 2026 | 339M (local enc.) | 230K CT volumes | DINOv3, SigLIP | classification, segmentation, retrieval |
+| 2025.10 | [BrainFound](#model-brainfound-202510) | arXiv | 307M (ViT-L) | 10K volumes | DINOv2 | classification |
+| 2025.09 | [MRI-PTPCa](#model-mri-ptpca-202509) | Nat. Cancer | _not published_ | none (1.3M image–pathology pairs) | BYOL | classification, grading |
+| 2025.08 | [Curia](#model-curia-202508) | arXiv | 86M | none (228M DICOM slices) | DINOv2 | General-purpose multimodal radiology representation learning |
+| 2025.07 | [Percival](#model-percival-202507) | medRxiv | 22M (DeiT-S enc.) | none (403K volume–report pairs) | InfoNCE, contrastive | retrieval, classification, prognosis |
+| 2025.04 | [Spark3D](#model-spark3d-202504) | CVPR 2025 | _not published_ | 44K MRI volumes | MAE | segmentation |
+| 2025.01 | [CT-FM](#model-ct-fm-202501) | arXiv | 77.8M | 148K CT volumes | SimCLR | segmentation, triage, retrieval |
+| 2025.01 | [3DINO](#model-3dino-202501) | arXiv | 307M (ViT-L) | ~100K volumes | 3DINO, self-supervised | classification, segmentation |
+| 2024.12 | [BME-X](#model-bme-x-202412) | Nat. Biomed. Eng. | _not published_ | not stated (516 participants) | supervised | segmentation, registration, classification |
+
+<sub><b>Model size</b> is the count the authors publish, with the component it covers in brackets — a vision encoder and a full vision–language model are not comparable. <i>not published</i> means the access routes were worked and no author source states one; <i>n/a</i> means the paper does not introduce a foundation model. <b>Training data</b> counts whole 3D volumes or scans used for pre-training, so a model trained on slices, frames, or image–text pairs shows what it used instead.</sub>
 
 ## Details
 
@@ -46,14 +48,16 @@ Click a model to expand its record.
 
 <a id="model-neurovfm-202607"></a>
 <details>
-<summary><b>NeuroVFM</b> — Health system learning enables generalist neuroimaging models <i>(Nat. Med. 2026-07)</i></summary>
+<summary><b>NeuroVFM</b> — Health system learning enables generalist neuroimaging models <i>(Nat. Med. 2026.07)</i></summary>
 
 **[Health system learning enables generalist neuroimaging models](https://www.nature.com/articles/s41591-026-04497-1)**
 
-*Nat. Med.* · 2026-07 · [doi:10.1038/s41591-026-04497-1](https://doi.org/10.1038/s41591-026-04497-1)
+*Nat. Med.* · 2026.07 · [doi:10.1038/s41591-026-04497-1](https://doi.org/10.1038/s41591-026-04497-1)
 
 | | |
 | --- | --- |
+| **Parameters** | 85.8M |
+| **Parameter note** | 85.8M is the released ViT-Base encoder; the paper also reports a ViT-Small variant with 21.7M parameters. Diagnostic heads and the findings LLM are separate. |
 | **Backbone** | 3D vision transformer |
 | **Pre-training** | `JEPA`<br>Volumetric joint-embedding predictive pretraining. |
 | **Training data** | CT and MRI neuroimaging<br>**5,240,000** volumes |
@@ -65,11 +69,11 @@ Click a model to expand its record.
 
 <a id="model-mars-202607"></a>
 <details>
-<summary><b>MARS</b> — Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications <i>(Nat. Biomed. Eng. 2026-07)</i></summary>
+<summary><b>MARS</b> — Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications <i>(Nat. Biomed. Eng. 2026.07)</i></summary>
 
 **[Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications](https://www.nature.com/articles/s41551-026-01740-5)**
 
-*Nat. Biomed. Eng.* · 2026-07 · [doi:10.1038/s41551-026-01740-5](https://doi.org/10.1038/s41551-026-01740-5)
+*Nat. Biomed. Eng.* · 2026.07 · [doi:10.1038/s41551-026-01740-5](https://doi.org/10.1038/s41551-026-01740-5)
 
 | | |
 | --- | --- |
@@ -84,11 +88,11 @@ Click a model to expand its record.
 
 <a id="model-multitaskcognition-202605"></a>
 <details>
-<summary><b>MultitaskCognition</b> — Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan <i>(Nat. Aging 2026-05)</i></summary>
+<summary><b>MultitaskCognition</b> — Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan <i>(Nat. Aging 2026.05)</i></summary>
 
 **[Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan](https://doi.org/10.1038/s43587-026-01121-2)**
 
-*Nat. Aging* · 2026-05 · [doi:10.1038/s43587-026-01121-2](https://doi.org/10.1038/s43587-026-01121-2)
+*Nat. Aging* · 2026.05 · [doi:10.1038/s43587-026-01121-2](https://doi.org/10.1038/s43587-026-01121-2)
 
 | | |
 | --- | --- |
@@ -103,14 +107,16 @@ Click a model to expand its record.
 
 <a id="model-fm-hct-202604"></a>
 <details>
-<summary><b>FM-HCT</b> — 3D foundation model for generalizable disease detection in head computed tomography <i>(Nat. Biomed. Eng. 2026-04)</i></summary>
+<summary><b>FM-HCT</b> — 3D foundation model for generalizable disease detection in head computed tomography <i>(Nat. Biomed. Eng. 2026.04)</i></summary>
 
 **[3D foundation model for generalizable disease detection in head computed tomography](https://www.nature.com/articles/s41551-026-01668-w)**
 
-*Nat. Biomed. Eng.* · 2026-04 · [doi:10.1038/s41551-026-01668-w](https://doi.org/10.1038/s41551-026-01668-w)
+*Nat. Biomed. Eng.* · 2026.04 · [doi:10.1038/s41551-026-01668-w](https://doi.org/10.1038/s41551-026-01668-w)
 
 | | |
 | --- | --- |
+| **Parameters** | 86M (ViT-B) |
+| **Parameter note** | The paper specifies a ViT-Base configuration (768-dim, 12 layers, 12 heads) on 512 patches of 12×12×12 voxels but does not print a parameter total; 86M follows the standard ViT-Base count. |
 | **Backbone** | Vision transformer |
 | **Pre-training** | `DINO` |
 | **Training data** | Head CT<br>**362,000** volumes |
@@ -122,11 +128,11 @@ Click a model to expand its record.
 
 <a id="model-neurofm-202604"></a>
 <details>
-<summary><b>NeuroFM</b> — Towards a general-purpose foundation model for functional MRI analysis <i>(Nat. Biomed. Eng. 2026-04)</i></summary>
+<summary><b>NeuroFM</b> — Towards a general-purpose foundation model for functional MRI analysis <i>(Nat. Biomed. Eng. 2026.04)</i></summary>
 
 **[Towards a general-purpose foundation model for functional MRI analysis](https://www.nature.com/articles/s41551-026-01666-y)**
 
-*Nat. Biomed. Eng.* · 2026-04 · [doi:10.1038/s41551-026-01666-y](https://doi.org/10.1038/s41551-026-01666-y)
+*Nat. Biomed. Eng.* · 2026.04 · [doi:10.1038/s41551-026-01666-y](https://doi.org/10.1038/s41551-026-01666-y)
 
 | | |
 | --- | --- |
@@ -141,11 +147,11 @@ Click a model to expand its record.
 
 <a id="model-tribev2-202603"></a>
 <details>
-<summary><b>TRIBEv2</b> — A foundation model of vision, audition, and language for in-silico neuroscience <i>(arXiv 2026-03)</i></summary>
+<summary><b>TRIBEv2</b> — A foundation model of vision, audition, and language for in-silico neuroscience <i>(arXiv 2026.03)</i></summary>
 
 **[A foundation model of vision, audition, and language for in-silico neuroscience](https://ai.meta.com/research/publications/a-foundation-model-of-vision-audition-and-language-for-in-silico-neuroscience/)**
 
-*arXiv* · 2026-03
+*arXiv* · 2026.03
 
 | | |
 | --- | --- |
@@ -160,14 +166,16 @@ Click a model to expand its record.
 
 <a id="model-merlin-202603"></a>
 <details>
-<summary><b>Merlin</b> — Merlin: a computed tomography vision–language foundation model and dataset <i>(Nature 2026-03)</i></summary>
+<summary><b>Merlin</b> — Merlin: a computed tomography vision–language foundation model and dataset <i>(Nature 2026.03)</i></summary>
 
 **[Merlin: a computed tomography vision–language foundation model and dataset](https://www.nature.com/articles/s41586-026-10181-8)**
 
-*Nature* · 2026-03 · [doi:10.1038/s41586-026-10181-8](https://doi.org/10.1038/s41586-026-10181-8)
+*Nature* · 2026.03 · [doi:10.1038/s41586-026-10181-8](https://doi.org/10.1038/s41586-026-10181-8)
 
 | | |
 | --- | --- |
+| **Parameters** | 121M |
+| **Parameter note** | 121M is the full vision–language model total from third-party benchmark tables (e.g. Pillar-0); the primary image encoder is an inflated 3D ResNet-152, paired with a Clinical Longformer text encoder. Not comparable with a vision-encoder-only count such as Curia-B's 86M. |
 | **Backbone** | ResNet vision encoder and Longformer text encoder |
 | **Pre-training** | `CLIP` |
 | **Training data** | CT volumes paired with clinical text<br>**25,500** CT volumes |
@@ -180,11 +188,11 @@ Click a model to expand its record.
 
 <a id="model-thymus-io-202603"></a>
 <details>
-<summary><b>Thymus-IO</b> — Thymic health and immunotherapy outcomes in patients with cancer <i>(Nature 2026-03)</i></summary>
+<summary><b>Thymus-IO</b> — Thymic health and immunotherapy outcomes in patients with cancer <i>(Nature 2026.03)</i></summary>
 
 **[Thymic health and immunotherapy outcomes in patients with cancer](https://www.nature.com/articles/s41586-026-10243-x)**
 
-*Nature* · 2026-03 · [doi:10.1038/s41586-026-10243-x](https://doi.org/10.1038/s41586-026-10243-x)
+*Nature* · 2026.03 · [doi:10.1038/s41586-026-10243-x](https://doi.org/10.1038/s41586-026-10243-x)
 
 | | |
 | --- | --- |
@@ -198,11 +206,11 @@ Click a model to expand its record.
 
 <a id="model-thymus-adult-202603"></a>
 <details>
-<summary><b>Thymus-Adult</b> — Thymic health consequences in adults <i>(Nature 2026-03)</i></summary>
+<summary><b>Thymus-Adult</b> — Thymic health consequences in adults <i>(Nature 2026.03)</i></summary>
 
 **[Thymic health consequences in adults](https://www.nature.com/articles/s41586-026-10242-y)**
 
-*Nature* · 2026-03 · [doi:10.1038/s41586-026-10242-y](https://doi.org/10.1038/s41586-026-10242-y)
+*Nature* · 2026.03 · [doi:10.1038/s41586-026-10242-y](https://doi.org/10.1038/s41586-026-10242-y)
 
 | | |
 | --- | --- |
@@ -216,11 +224,11 @@ Click a model to expand its record.
 
 <a id="model-omafound-202602"></a>
 <details>
-<summary><b>OMAFound</b> — A foundation model for breast and lung cancer screening using non-contrast computed tomography <i>(Nat. Health 2026-02)</i></summary>
+<summary><b>OMAFound</b> — A foundation model for breast and lung cancer screening using non-contrast computed tomography <i>(Nat. Health 2026.02)</i></summary>
 
 **[A foundation model for breast and lung cancer screening using non-contrast computed tomography](https://doi.org/10.1038/s44360-026-00055-8)**
 
-*Nat. Health* · 2026-02 · [doi:10.1038/s44360-026-00055-8](https://doi.org/10.1038/s44360-026-00055-8)
+*Nat. Health* · 2026.02 · [doi:10.1038/s44360-026-00055-8](https://doi.org/10.1038/s44360-026-00055-8)
 
 | | |
 | --- | --- |
@@ -235,11 +243,11 @@ Click a model to expand its record.
 
 <a id="model-cmr-transformer-202602"></a>
 <details>
-<summary><b>CMR Transformer</b> — A generalizable deep learning system for cardiac MRI <i>(Nat. Biomed. Eng. 2026-02)</i></summary>
+<summary><b>CMR Transformer</b> — A generalizable deep learning system for cardiac MRI <i>(Nat. Biomed. Eng. 2026.02)</i></summary>
 
 **[A generalizable deep learning system for cardiac MRI](https://www.nature.com/articles/s41551-026-01637-3)**
 
-*Nat. Biomed. Eng.* · 2026-02 · [doi:10.1038/s41551-026-01637-3](https://doi.org/10.1038/s41551-026-01637-3)
+*Nat. Biomed. Eng.* · 2026.02 · [doi:10.1038/s41551-026-01637-3](https://doi.org/10.1038/s41551-026-01637-3)
 
 | | |
 | --- | --- |
@@ -254,14 +262,16 @@ Click a model to expand its record.
 
 <a id="model-brainiac-202602"></a>
 <details>
-<summary><b>BrainIAC</b> — A generalizable foundation model for analysis of human brain MRI <i>(Nat. Neurosci. 2026-02)</i></summary>
+<summary><b>BrainIAC</b> — A generalizable foundation model for analysis of human brain MRI <i>(Nat. Neurosci. 2026.02)</i></summary>
 
 **[A generalizable foundation model for analysis of human brain MRI](https://www.nature.com/articles/s41593-026-02202-6)**
 
-*Nat. Neurosci.* · 2026-02 · [doi:10.1038/s41593-026-02202-6](https://doi.org/10.1038/s41593-026-02202-6)
+*Nat. Neurosci.* · 2026.02 · [doi:10.1038/s41593-026-02202-6](https://doi.org/10.1038/s41593-026-02202-6)
 
 | | |
 | --- | --- |
+| **Parameters** | 88.4M |
+| **Parameter note** | MONAI ViT-B/16³ (96×96×96 input, 16³ patches); figure from the released checkpoint configuration. |
 | **Backbone** | ViT-B |
 | **Pre-training** | `SimCLR` |
 | **Training data** | **32,000** MRI scans |
@@ -273,11 +283,11 @@ Click a model to expand its record.
 
 <a id="model-ct-clip-ct-chat-202602"></a>
 <details>
-<summary><b>CT-CLIP / CT-CHAT</b> — Generalist foundation models from a multimodal dataset for 3D computed tomography <i>(Nat. Biomed. Eng. 2026-02)</i></summary>
+<summary><b>CT-CLIP / CT-CHAT</b> — Generalist foundation models from a multimodal dataset for 3D computed tomography <i>(Nat. Biomed. Eng. 2026.02)</i></summary>
 
 **[Generalist foundation models from a multimodal dataset for 3D computed tomography](https://www.nature.com/articles/s41551-025-01599-y)**
 
-*Nat. Biomed. Eng.* · 2026-02 · [doi:10.1038/s41551-025-01599-y](https://doi.org/10.1038/s41551-025-01599-y)
+*Nat. Biomed. Eng.* · 2026.02 · [doi:10.1038/s41551-025-01599-y](https://doi.org/10.1038/s41551-025-01599-y)
 
 | | |
 | --- | --- |
@@ -292,14 +302,16 @@ Click a model to expand its record.
 
 <a id="model-prima-202602"></a>
 <details>
-<summary><b>PRIMA</b> — Learning neuroimaging models from health system-scale data <i>(Nat. Biomed. Eng. 2026-02)</i></summary>
+<summary><b>PRIMA</b> — Learning neuroimaging models from health system-scale data <i>(Nat. Biomed. Eng. 2026.02)</i></summary>
 
 **[Learning neuroimaging models from health system-scale data](https://www.nature.com/articles/s41551-025-01608-0)**
 
-*Nat. Biomed. Eng.* · 2026-02 · [doi:10.1038/s41551-025-01608-0](https://doi.org/10.1038/s41551-025-01608-0)
+*Nat. Biomed. Eng.* · 2026.02 · [doi:10.1038/s41551-025-01608-0](https://doi.org/10.1038/s41551-025-01608-0)
 
 | | |
 | --- | --- |
+| **Parameters** | 56.6M |
+| **Parameter note** | 56.584M is the combined sequence and study hierarchical ViT visual encoder; the VQ-VAE volume tokenizer and text tower are excluded. |
 | **Backbone** | Hierarchical vision transformer |
 | **Pre-training** | `CLIP` |
 | **Training data** | **221,000** MRI studies · **5,600,000** sequences |
@@ -310,16 +322,16 @@ Click a model to expand its record.
 
 <a id="model-maoss-202602"></a>
 <details>
-<summary><b>MAOSS</b> — Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease <i>(Nat. Commun. 2026-02)</i></summary>
+<summary><b>MAOSS</b> — Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease <i>(Nat. Commun. 2026.02)</i></summary>
 
 **[Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease](https://www.nature.com/articles/s41467-026-68414-3)**
 
-*Nat. Commun.* · 2026-02 · [doi:10.1038/s41467-026-68414-3](https://doi.org/10.1038/s41467-026-68414-3)
+*Nat. Commun.* · 2026.02 · [doi:10.1038/s41467-026-68414-3](https://doi.org/10.1038/s41467-026-68414-3)
 
 | | |
 | --- | --- |
 | **Backbone** | 3D ResNet-34 and ViLT |
-| **Pre-training** | Not recorded |
+| **Pre-training** | `_n/a_`<br>Supervised multimodal training with a missing-aware alignment module; not a self-supervised foundation-model pre-training recipe. |
 | **Training data** | Multisite imaging data and information from 226 publications |
 | **Downstream tasks** | `classification`, `prognosis`<br>Screening, staging and progression-risk stratification of steatotic liver disease. |
 | **Modalities** | `CT`, `text` |
@@ -329,11 +341,11 @@ Click a model to expand its record.
 
 <a id="model-afloc-202601"></a>
 <details>
-<summary><b>AFLoc</b> — A multimodal vision–language model for generalizable annotation-free pathology localization <i>(Nat. Biomed. Eng. 2026-01)</i></summary>
+<summary><b>AFLoc</b> — A multimodal vision–language model for generalizable annotation-free pathology localization <i>(Nat. Biomed. Eng. 2026.01)</i></summary>
 
 **[A multimodal vision–language model for generalizable annotation-free pathology localization](https://www.nature.com/articles/s41551-025-01574-7)**
 
-*Nat. Biomed. Eng.* · 2026-01 · [doi:10.1038/s41551-025-01574-7](https://doi.org/10.1038/s41551-025-01574-7)
+*Nat. Biomed. Eng.* · 2026.01 · [doi:10.1038/s41551-025-01574-7](https://doi.org/10.1038/s41551-025-01574-7)
 
 | | |
 | --- | --- |
@@ -349,16 +361,16 @@ Click a model to expand its record.
 
 <a id="model-deepmriprep-202601"></a>
 <details>
-<summary><b>deepmriprep</b> — deepmriprep: voxel-based morphometry preprocessing via deep neural networks <i>(Nat. Comput. Sci. 2026-01)</i></summary>
+<summary><b>deepmriprep</b> — deepmriprep: voxel-based morphometry preprocessing via deep neural networks <i>(Nat. Comput. Sci. 2026.01)</i></summary>
 
 **[deepmriprep: voxel-based morphometry preprocessing via deep neural networks](https://www.nature.com/articles/s43588-026-00953-7)**
 
-*Nat. Comput. Sci.* · 2026-01 · [doi:10.1038/s43588-026-00953-7](https://doi.org/10.1038/s43588-026-00953-7)
+*Nat. Comput. Sci.* · 2026.01 · [doi:10.1038/s43588-026-00953-7](https://doi.org/10.1038/s43588-026-00953-7)
 
 | | |
 | --- | --- |
 | **Backbone** | 3D U-Net |
-| **Pre-training** | Not recorded |
+| **Pre-training** | `_n/a_`<br>Supervised voxel-based morphometry preprocessing; the paper does not introduce a foundation-model pre-training objective. |
 | **Training data** | **685** MRI scans |
 | **Downstream tasks** | `preprocessing`<br>Deep-learning voxel-based morphometry preprocessing. |
 | **Modalities** | `MRI` |
@@ -368,11 +380,11 @@ Click a model to expand its record.
 
 <a id="model-fomo25-202601"></a>
 <details>
-<summary><b>FOMO25</b> — From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models <i>(arXiv 2026-01)</i></summary>
+<summary><b>FOMO25</b> — From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models <i>(arXiv 2026.01)</i></summary>
 
 **[From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models](https://arxiv.org/abs/2601.13166)**
 
-*arXiv* · 2026-01 · [arXiv:2601.13166](https://arxiv.org/abs/2601.13166)
+*arXiv* · 2026.01 · [arXiv:2601.13166](https://arxiv.org/abs/2601.13166)
 
 | | |
 | --- | --- |
@@ -387,14 +399,16 @@ Click a model to expand its record.
 
 <a id="model-voco-202512"></a>
 <details>
-<summary><b>VoCo</b> — Large-scale 3D medical image pre-training with geometric context priors <i>(IEEE TPAMI 2025-12)</i></summary>
+<summary><b>VoCo</b> — Large-scale 3D medical image pre-training with geometric context priors <i>(IEEE TPAMI 2025.12)</i></summary>
 
 **[Large-scale 3D medical image pre-training with geometric context priors](https://doi.org/10.1109/tpami.2025.3639593)**
 
-*IEEE TPAMI* · 2025-12 · [doi:10.1109/TPAMI.2025.3639593](https://doi.org/10.1109/tpami.2025.3639593)
+*IEEE TPAMI* · 2025.12 · [doi:10.1109/TPAMI.2025.3639593](https://doi.org/10.1109/tpami.2025.3639593)
 
 | | |
 | --- | --- |
+| **Parameters** | 53M |
+| **Parameter note** | 53M matches the released VoCo_B_SSL_head checkpoint (SwinUNETR Base, feature_size=48); the repository also lists 31M–1.2B variants. |
 | **Backbone** | SwinUNETR |
 | **Pre-training** | `VoCo`, `contrastive learning`<br>Volume contrastive learning with geometric context priors. |
 | **Training data** | PreCT-160K<br>**160,000** CT volumes |
@@ -408,14 +422,16 @@ Click a model to expand its record.
 
 <a id="model-tap-ct-202512"></a>
 <details>
-<summary><b>TAP-CT</b> — TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models <i>(arXiv 2025-12)</i></summary>
+<summary><b>TAP-CT</b> — TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models <i>(arXiv 2025.12)</i></summary>
 
 **[TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models](https://arxiv.org/abs/2512.00872)**
 
-*arXiv* · 2025-12 · [arXiv:2512.00872](https://arxiv.org/abs/2512.00872)
+*arXiv* · 2025.12 · [arXiv:2512.00872](https://arxiv.org/abs/2512.00872)
 
 | | |
 | --- | --- |
+| **Parameters** | 86M |
+| **Parameter note** | Table 1 in the TAP-CT paper lists 86.0M for TAP-B-3D (ViT-Base 3D); the HuggingFace checkpoint reports 87.1M safetensors total. |
 | **Backbone** | 3D vision transformer |
 | **Pre-training** | `DINOv2` |
 | **Training data** | **105,000** CT volumes |
@@ -428,17 +444,17 @@ Click a model to expand its record.
 
 <a id="model-anymc3d-202512"></a>
 <details>
-<summary><b>AnyMC3D</b> — Revisiting 2D foundation models for scalable 3D medical image classification <i>(arXiv 2025-12)</i></summary>
+<summary><b>AnyMC3D</b> — Revisiting 2D foundation models for scalable 3D medical image classification <i>(arXiv 2025.12)</i></summary>
 
 **[Revisiting 2D foundation models for scalable 3D medical image classification](https://arxiv.org/abs/2512.12887)**
 
-*arXiv* · 2025-12 · [arXiv:2512.12887](https://arxiv.org/abs/2512.12887)
+*arXiv* · 2025.12 · [arXiv:2512.12887](https://arxiv.org/abs/2512.12887)
 
 | | |
 | --- | --- |
 | **Backbone** | DINOv2 and DINOv3 backbones with lightweight task plugins |
 | **Pre-training** | `DINOv2`, `DINOv3` |
-| **Training data** | Numeric scale not recorded |
+| **Training data** | none (frozen DINOv2/3)<br>Uses frozen 2D foundation-model backbones with lightweight task plugins; no native 3D pre-training corpus. |
 | **Downstream tasks** | `classification`<br>Scalable evaluation across 12 three-dimensional classification tasks. |
 | **Modalities** | `CT`, `MRI` |
 
@@ -446,14 +462,16 @@ Click a model to expand its record.
 
 <a id="model-pillar-0-202511"></a>
 <details>
-<summary><b>Pillar-0</b> — Pillar-0: a new frontier for radiology foundation models <i>(arXiv 2025-11)</i></summary>
+<summary><b>Pillar-0</b> — Pillar-0: a new frontier for radiology foundation models <i>(arXiv 2025.11)</i></summary>
 
 **[Pillar-0: a new frontier for radiology foundation models](https://arxiv.org/abs/2511.17803)**
 
-*arXiv* · 2025-11 · [arXiv:2511.17803](https://arxiv.org/abs/2511.17803)
+*arXiv* · 2025.11 · [arXiv:2511.17803](https://arxiv.org/abs/2511.17803)
 
 | | |
 | --- | --- |
+| **Parameters** | 79M |
+| **Parameter note** | 79M is the Atlas vision encoder only; pretraining aligns it with a frozen Qwen3-Embedding-8B text encoder, which is not included. |
 | **Backbone** | Atlas |
 | **Pre-training** | `contrastive`, `vision-language`<br>CLIP-like radiology pretraining. |
 | **Training data** | Abdomen-pelvis, chest and head CT plus breast MRI<br>**155,292** volumes |
@@ -466,14 +484,16 @@ Click a model to expand its record.
 
 <a id="model-spectre-202511"></a>
 <details>
-<summary><b>SPECTRE</b> — Scaling self-supervised and cross-modal pretraining for volumetric CT transformers <i>(CVPR 2026 2025-11)</i></summary>
+<summary><b>SPECTRE</b> — Scaling self-supervised and cross-modal pretraining for volumetric CT transformers <i>(CVPR 2026 2025.11)</i></summary>
 
 **[Scaling self-supervised and cross-modal pretraining for volumetric CT transformers](https://arxiv.org/abs/2511.17209)**
 
-*CVPR 2026* · 2025-11 · [arXiv:2511.17209](https://arxiv.org/abs/2511.17209)
+*CVPR 2026* · 2025.11 · [arXiv:2511.17209](https://arxiv.org/abs/2511.17209)
 
 | | |
 | --- | --- |
+| **Parameters** | 339M |
+| **Parameter note** | 339M is the local ViT-L backbone (d=1080, 24 layers); the full SPECTRE release also includes a global transformer and cross-modal components. |
 | **Backbone** | Local and global 3D vision transformers |
 | **Pre-training** | `DINOv3`, `SigLIP`<br>Self-supervised and cross-modal pretraining. |
 | **Training data** | **230,000** CT volumes |
@@ -485,14 +505,16 @@ Click a model to expand its record.
 
 <a id="model-brainfound-202510"></a>
 <details>
-<summary><b>BrainFound</b> — Towards generalisable foundation models for brain MRI <i>(arXiv 2025-10)</i></summary>
+<summary><b>BrainFound</b> — Towards generalisable foundation models for brain MRI <i>(arXiv 2025.10)</i></summary>
 
 **[Towards generalisable foundation models for brain MRI](https://arxiv.org/abs/2510.23415)**
 
-*arXiv* · 2025-10 · [arXiv:2510.23415](https://arxiv.org/abs/2510.23415)
+*arXiv* · 2025.10 · [arXiv:2510.23415](https://arxiv.org/abs/2510.23415)
 
 | | |
 | --- | --- |
+| **Parameters** | 307M |
+| **Parameter note** | ViT-Large/14 DINOv2 backbone; each axial slice is processed independently at 224×224. |
 | **Backbone** | ViT-L |
 | **Pre-training** | `DINOv2` |
 | **Training data** | **10,000** MRI volumes |
@@ -504,17 +526,17 @@ Click a model to expand its record.
 
 <a id="model-mri-ptpca-202509"></a>
 <details>
-<summary><b>MRI-PTPCa</b> — An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer <i>(Nat. Cancer 2025-09)</i></summary>
+<summary><b>MRI-PTPCa</b> — An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer <i>(Nat. Cancer 2025.09)</i></summary>
 
 **[An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer](https://www.nature.com/articles/s43018-025-01041-x)**
 
-*Nat. Cancer* · 2025-09 · [doi:10.1038/s43018-025-01041-x](https://doi.org/10.1038/s43018-025-01041-x)
+*Nat. Cancer* · 2025.09 · [doi:10.1038/s43018-025-01041-x](https://doi.org/10.1038/s43018-025-01041-x)
 
 | | |
 | --- | --- |
 | **Backbone** | CNN and vision transformer |
 | **Pre-training** | `BYOL` |
-| **Training data** | Numeric scale not recorded |
+| **Training data** | Nearly **1,300,000** image–pathology pairs from more than **5,500** patients |
 | **Downstream tasks** | `classification`, `grading`<br>Non-invasive prostate-cancer diagnosis and grading. |
 | **Modalities** | `MRI`, `histopathology` |
 | **Code** | [github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer](https://github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer) |
@@ -523,14 +545,16 @@ Click a model to expand its record.
 
 <a id="model-curia-202508"></a>
 <details>
-<summary><b>Curia</b> — Curia: a multi-modal foundation model for radiology <i>(arXiv 2025-08)</i></summary>
+<summary><b>Curia</b> — Curia: a multi-modal foundation model for radiology <i>(arXiv 2025.08)</i></summary>
 
 **[Curia: a multi-modal foundation model for radiology](https://arxiv.org/abs/2509.06830)**
 
-*arXiv* · 2025-08 · [arXiv:2509.06830](https://arxiv.org/abs/2509.06830)
+*arXiv* · 2025.08 · [arXiv:2509.06830](https://arxiv.org/abs/2509.06830)
 
 | | |
 | --- | --- |
+| **Parameters** | 86M |
+| **Parameter note** | Curia-B (ViT-B) released for downstream use; the paper also trains Curia-L at 300M on the full 200M-image corpus. |
 | **Backbone** | ViT-B |
 | **Pre-training** | `DINOv2` |
 | **Training data** | **164,000,000** CT and **64,000,000** MRI DICOM images |
@@ -542,14 +566,16 @@ Click a model to expand its record.
 
 <a id="model-percival-202507"></a>
 <details>
-<summary><b>Percival</b> — A pan-organ vision–language model for generalizable 3D CT representations <i>(medRxiv 2025-07)</i></summary>
+<summary><b>Percival</b> — A pan-organ vision–language model for generalizable 3D CT representations <i>(medRxiv 2025.07)</i></summary>
 
 **[A pan-organ vision–language model for generalizable 3D CT representations](https://pmc.ncbi.nlm.nih.gov/articles/PMC12236870/)**
 
-*medRxiv* · 2025-07
+*medRxiv* · 2025.07
 
 | | |
 | --- | --- |
+| **Parameters** | 22M |
+| **Parameter note** | DeiT-Small Patch16 vision encoder adapted for 3D patches; the Clinical Longformer text encoder is excluded. Standard DeiT-S count. |
 | **Backbone** | 3D DeiT |
 | **Pre-training** | `InfoNCE`, `contrastive`<br>Vision-language pretraining with CT volumes and reports. |
 | **Training data** | More than<br>**403,000** CT volumes |
@@ -561,11 +587,11 @@ Click a model to expand its record.
 
 <a id="model-spark3d-202504"></a>
 <details>
-<summary><b>Spark3D</b> — Revisiting MAE pre-training for 3D medical image segmentation <i>(CVPR 2025 2025-04)</i></summary>
+<summary><b>Spark3D</b> — Revisiting MAE pre-training for 3D medical image segmentation <i>(CVPR 2025 2025.04)</i></summary>
 
 **[Revisiting MAE pre-training for 3D medical image segmentation](https://doi.org/10.1109/CVPR52734.2025.00489)**
 
-*CVPR 2025* · 2025-04 · [doi:10.1109/CVPR52734.2025.00489](https://doi.org/10.1109/CVPR52734.2025.00489)
+*CVPR 2025* · 2025.04 · [doi:10.1109/CVPR52734.2025.00489](https://doi.org/10.1109/CVPR52734.2025.00489)
 
 | | |
 | --- | --- |
@@ -580,14 +606,16 @@ Click a model to expand its record.
 
 <a id="model-ct-fm-202501"></a>
 <details>
-<summary><b>CT-FM</b> — Vision foundation models for computed tomography <i>(arXiv 2025-01)</i></summary>
+<summary><b>CT-FM</b> — Vision foundation models for computed tomography <i>(arXiv 2025.01)</i></summary>
 
 **[Vision foundation models for computed tomography](https://arxiv.org/abs/2501.09001)**
 
-*arXiv* · 2025-01 · [arXiv:2501.09001](https://arxiv.org/abs/2501.09001)
+*arXiv* · 2025.01 · [arXiv:2501.09001](https://arxiv.org/abs/2501.09001)
 
 | | |
 | --- | --- |
+| **Parameters** | 77.8M |
+| **Parameter note** | SegResNet encoder; stated in the GitHub repository and HuggingFace model card. |
 | **Backbone** | SegResEncoder |
 | **Pre-training** | `SimCLR` |
 | **Training data** | IDC corpus<br>**148,000** CT volumes |
@@ -601,14 +629,16 @@ Click a model to expand its record.
 
 <a id="model-3dino-202501"></a>
 <details>
-<summary><b>3DINO</b> — A generalizable 3D framework and model for self-supervised learning in medical imaging <i>(arXiv 2025-01)</i></summary>
+<summary><b>3DINO</b> — A generalizable 3D framework and model for self-supervised learning in medical imaging <i>(arXiv 2025.01)</i></summary>
 
 **[A generalizable 3D framework and model for self-supervised learning in medical imaging](https://arxiv.org/abs/2501.11755)**
 
-*arXiv* · 2025-01 · [arXiv:2501.11755](https://arxiv.org/abs/2501.11755)
+*arXiv* · 2025.01 · [arXiv:2501.11755](https://arxiv.org/abs/2501.11755)
 
 | | |
 | --- | --- |
+| **Parameters** | 307M |
+| **Parameter note** | 3DINO-ViT uses a ViT-Large backbone with a 3D ViT-Adapter module for dense downstream tasks. |
 | **Backbone** | Vision transformer |
 | **Pre-training** | `3DINO`, `self-supervised` |
 | **Training data** | **1,300** patients |
@@ -620,17 +650,17 @@ Click a model to expand its record.
 
 <a id="model-bme-x-202412"></a>
 <details>
-<summary><b>BME-X</b> — A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks <i>(Nat. Biomed. Eng. 2024-12)</i></summary>
+<summary><b>BME-X</b> — A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks <i>(Nat. Biomed. Eng. 2024.12)</i></summary>
 
 **[A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks](https://www.nature.com/articles/s41551-024-01283-7)**
 
-*Nat. Biomed. Eng.* · 2024-12 · [doi:10.1038/s41551-024-01283-7](https://doi.org/10.1038/s41551-024-01283-7)
+*Nat. Biomed. Eng.* · 2024.12 · [doi:10.1038/s41551-024-01283-7](https://doi.org/10.1038/s41551-024-01283-7)
 
 | | |
 | --- | --- |
 | **Backbone** | U-Net CNN |
-| **Pre-training** | Not recorded |
-| **Training data** | Numeric scale not recorded |
+| **Pre-training** | `supervised`<br>Tissue-classification then tissue-aware enhancement; not a self-supervised encoder. |
+| **Training data** | 52 foetal participants and 464 Baby Connectome Project participants (0–6 years)<br>**516** participants |
 | **Downstream tasks** | `segmentation`, `registration`, `classification`<br>MRI enhancement and downstream image-analysis tasks. |
 | **Modalities** | `MRI` |
 | **Code** | [github.com/DBC-Lab/Brain_MRI_Enhancement](https://github.com/DBC-Lab/Brain_MRI_Enhancement) |

--- a/radiology.md
+++ b/radiology.md
@@ -4,706 +4,635 @@ CT, MRI, PET, X-ray and fMRI foundation models.
 
 **Maintainer:** [Judy Lyu](https://github.com/judylyu)
 
-**31 papers** · **Last updated: 2026-08** · [Back to index](README.md)
+**31 entries** · [Back to index](README.md)
 
-## Paper overview
-
-Click a model name to jump to its expandable record. A dash (`—`) means that the corresponding value has not been confirmed from the paper or an official release.
-
-
-| Date    | Model                                                  | Venue             | Modality                  | Training data                     | Training / adaptation              | Downstream tasks                                                         |
-| ------- | ------------------------------------------------------ | ----------------- | ------------------------- | --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| 2026-07 | [NeuroVFM](#model-neurovfm-202607)                     | Nat. Med.         | CT, MRI                   | 5.24M volumes                     | JEPA                               | classification, report generation, retrieval, triage, registration       |
-| 2026-07 | [MARS](#model-mars-202607)                             | Nat. Biomed. Eng. | MRI                       | 336K volumes                      | MAE, contrastive learning          | classification, segmentation, registration, report generation, prognosis |
-| 2026-05 | [MultitaskCognition](#model-multitaskcognition-202605) | Nat. Aging        | MRI                       | ~3K studies                       | supervised, transfer learning      | classification, segmentation, regression, prognosis                      |
-| 2026-04 | [FM-HCT](#model-fm-hct-202604)                         | Nat. Biomed. Eng. | CT                        | 362K volumes                      | DINO                               | classification, retrieval                                                |
-| 2026-04 | [NeuroFM](#model-neurofm-202604)                       | Nat. Biomed. Eng. | fMRI                      | 8.65M frames                      | MAE                                | regression, classification, prognosis                                    |
-| 2026-03 | [TRIBEv2](#model-tribev2-202603)                       | arXiv             | fMRI, vision, audio, text | Multiple datasets                 | Multimodal representation learning | regression                                                               |
-| 2026-03 | [Merlin](#model-merlin-202603)                         | Nature            | CT, text                  | 25.5K CT volumes                  | CLIP                               | classification, segmentation, retrieval, report generation, prognosis    |
-| 2026-03 | [Thymus-IO](#model-thymus-io-202603)                   | Nature            | CT                        | 5.7K CT volumes                   | SwAV                               | classification, prognosis                                                |
-| 2026-03 | [Thymus-Adult](#model-thymus-adult-202603)             | Nature            | CT                        | 5.7K CT volumes                   | SwAV                               | classification                                                           |
-| 2026-02 | [OMAFound](#model-omafound-202602)                     | Nat. Health       | CT                        | 325.2K CT volumes                 | self-supervised                    | classification                                                           |
-| 2026-02 | [CMR Transformer](#model-cmr-transformer-202602)       | Nat. Biomed. Eng. | MRI, text                 | ~21K scans                        | InfoNCE, contrastive               | regression, classification                                               |
-| 2026-02 | [BrainIAC](#model-brainiac-202602)                     | Nat. Neurosci.    | MRI                       | 32K scans                         | SimCLR                             | classification, regression, segmentation, prognosis                      |
-| 2026-02 | [CT-CLIP / CT-CHAT](#model-ct-clip-ct-chat-202602)     | Nat. Biomed. Eng. | CT, text                  | 25.7K CT volumes                  | CLIP                               | classification, retrieval, VQA                                           |
-| 2026-02 | [PRIMA](#model-prima-202602)                           | Nat. Biomed. Eng. | MRI, text                 | 221K studies                      | CLIP                               | classification, triage, regression                                       |
-| 2026-02 | [MAOSS](#model-maoss-202602)                           | Nat. Commun.      | CT, text                  | Multisite data + 226 publications | —                                  | classification, prognosis                                                |
-| 2026-01 | [AFLoc](#model-afloc-202601)                           | Nat. Biomed. Eng. | X-ray, text               | MIMIC-CXR                         | CLIP                               | localization, classification                                             |
-| 2026-01 | [deepmriprep](#model-deepmriprep-202601)               | Nat. Comput. Sci. | MRI                       | 685 MRI scans                     | —                                  | preprocessing                                                            |
-| 2026-01 | [FOMO25](#model-fomo25-202601)                         | arXiv             | MRI                       | 176K volumes                      | MAE                                | segmentation, classification, regression                                 |
-| 2025-12 | [VoCo](#model-voco-202512)                             | IEEE TPAMI        | CT                        | 160K volumes                      | VoCo, contrastive learning         | segmentation, classification, regression, vision-language modeling       |
-| 2025-12 | [TAP-CT](#model-tap-ct-202512)                         | arXiv             | CT                        | 105K volumes                      | DINOv2                             | segmentation, classification                                             |
-| 2025-12 | [AnyMC3D](#model-anymc3d-202512)                       | arXiv             | CT, MRI                   | —                                 | DINOv2, DINOv3                     | classification                                                           |
-| 2025-11 | [Pillar-0](#model-pillar-0-202511)                     | arXiv             | CT, MRI, text             | ~155K volumes                     | contrastive, vision-language       | classification, prognosis                                                |
-| 2025-11 | [SPECTRE](#model-spectre-202511)                       | CVPR 2026         | CT, text                  | 230K CT volumes                   | DINOv3, SigLIP                     | classification, segmentation, retrieval                                  |
-| 2025-10 | [BrainFound](#model-brainfound-202510)                 | arXiv             | MRI                       | 10K volumes                       | DINOv2                             | classification                                                           |
-| 2025-09 | [MRI-PTPCa](#model-mri-ptpca-202509)                   | Nat. Cancer       | MRI, histopathology       | —                                 | BYOL                               | classification, grading                                                  |
-| 2025-08 | [Curia](#model-curia-202508)                           | arXiv             | CT, MRI                   | 228M DICOM images                 | DINOv2                             | General-purpose multimodal radiology representation learning             |
-| 2025-07 | [Percival](#model-percival-202507)                     | medRxiv           | CT, text                  | 403K CT volumes                   | InfoNCE, contrastive               | retrieval, classification, prognosis                                     |
-| 2025-04 | [Spark3D](#model-spark3d-202504)                       | CVPR 2025         | MRI                       | 44K MRI volumes                   | MAE                                | segmentation                                                             |
-| 2025-01 | [CT-FM](#model-ct-fm-202501)                           | arXiv             | CT                        | 148K CT volumes                   | SimCLR                             | segmentation, triage, retrieval                                          |
-| 2025-01 | [3DINO](#model-3dino-202501)                           | arXiv             | CT, MRI                   | 1.3K patients                     | 3DINO, self-supervised             | classification, segmentation                                             |
-| 2024-12 | [BME-X](#model-bme-x-202412)                           | Nat. Biomed. Eng. | MRI                       | —                                 | —                                  | segmentation, registration, classification                               |
-
-
-
+| Date | Model | Venue | Model size | Training data | Pre-training | Downstream tasks |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-07 | [NeuroVFM](#model-neurovfm-202607) | Nat. Med. | — | 5.24M volumes | JEPA | classification, report generation, retrieval +2 |
+| 2026-07 | [MARS](#model-mars-202607) | Nat. Biomed. Eng. | — | 336K volumes | MAE, contrastive learning | classification, segmentation, registration +2 |
+| 2026-05 | [MultitaskCognition](#model-multitaskcognition-202605) | Nat. Aging | — | ~3K studies | supervised, transfer learning | classification, segmentation, regression +1 |
+| 2026-04 | [FM-HCT](#model-fm-hct-202604) | Nat. Biomed. Eng. | — | 362K volumes | DINO | classification, retrieval |
+| 2026-04 | [NeuroFM](#model-neurofm-202604) | Nat. Biomed. Eng. | — | 8.65M frames | MAE | regression, classification, prognosis |
+| 2026-03 | [TRIBEv2](#model-tribev2-202603) | arXiv | — | Multiple datasets | Multimodal representation learning | regression |
+| 2026-03 | [Merlin](#model-merlin-202603) | Nature | — | 25.5K CT volumes | CLIP | classification, segmentation, retrieval +2 |
+| 2026-03 | [Thymus-IO](#model-thymus-io-202603) | Nature | — | 5.7K CT volumes | SwAV | classification, prognosis |
+| 2026-03 | [Thymus-Adult](#model-thymus-adult-202603) | Nature | — | 5.7K CT volumes | SwAV | classification |
+| 2026-02 | [OMAFound](#model-omafound-202602) | Nat. Health | — | 325.2K CT volumes | self-supervised | classification |
+| 2026-02 | [CMR Transformer](#model-cmr-transformer-202602) | Nat. Biomed. Eng. | — | ~21K scans | InfoNCE, contrastive | regression, classification |
+| 2026-02 | [BrainIAC](#model-brainiac-202602) | Nat. Neurosci. | — | 32K scans | SimCLR | classification, regression, segmentation +1 |
+| 2026-02 | [CT-CLIP / CT-CHAT](#model-ct-clip-ct-chat-202602) | Nat. Biomed. Eng. | — | 25.7K CT volumes | CLIP | classification, retrieval, VQA |
+| 2026-02 | [PRIMA](#model-prima-202602) | Nat. Biomed. Eng. | — | 221K studies | CLIP | classification, triage, regression |
+| 2026-02 | [MAOSS](#model-maoss-202602) | Nat. Commun. | — | Multisite data + 226 publications | — | classification, prognosis |
+| 2026-01 | [AFLoc](#model-afloc-202601) | Nat. Biomed. Eng. | — | MIMIC-CXR | CLIP | localization, classification |
+| 2026-01 | [deepmriprep](#model-deepmriprep-202601) | Nat. Comput. Sci. | — | 685 MRI scans | — | preprocessing |
+| 2026-01 | [FOMO25](#model-fomo25-202601) | arXiv | — | 176K volumes | MAE | segmentation, classification, regression |
+| 2025-12 | [VoCo](#model-voco-202512) | IEEE TPAMI | — | 160K volumes | VoCo, contrastive learning | segmentation, classification, regression +1 |
+| 2025-12 | [TAP-CT](#model-tap-ct-202512) | arXiv | — | 105K volumes | DINOv2 | segmentation, classification |
+| 2025-12 | [AnyMC3D](#model-anymc3d-202512) | arXiv | — | — | DINOv2, DINOv3 | classification |
+| 2025-11 | [Pillar-0](#model-pillar-0-202511) | arXiv | — | ~155K volumes | contrastive, vision-language | classification, prognosis |
+| 2025-11 | [SPECTRE](#model-spectre-202511) | CVPR 2026 | — | 230K CT volumes | DINOv3, SigLIP | classification, segmentation, retrieval |
+| 2025-10 | [BrainFound](#model-brainfound-202510) | arXiv | — | 10K volumes | DINOv2 | classification |
+| 2025-09 | [MRI-PTPCa](#model-mri-ptpca-202509) | Nat. Cancer | — | — | BYOL | classification, grading |
+| 2025-08 | [Curia](#model-curia-202508) | arXiv | — | 228M DICOM images | DINOv2 | General-purpose multimodal radiology representation learning |
+| 2025-07 | [Percival](#model-percival-202507) | medRxiv | — | 403K CT volumes | InfoNCE, contrastive | retrieval, classification, prognosis |
+| 2025-04 | [Spark3D](#model-spark3d-202504) | CVPR 2025 | — | 44K MRI volumes | MAE | segmentation |
+| 2025-01 | [CT-FM](#model-ct-fm-202501) | arXiv | — | 148K CT volumes | SimCLR | segmentation, triage, retrieval |
+| 2025-01 | [3DINO](#model-3dino-202501) | arXiv | — | 1.3K patients | 3DINO, self-supervised | classification, segmentation |
+| 2024-12 | [BME-X](#model-bme-x-202412) | Nat. Biomed. Eng. | — | — | — | segmentation, registration, classification |
 
 ## Details
 
 Click a model to expand its record.
 
-
-
-**NeuroVFM** — Health system learning enables generalist neuroimaging models *(Nat. Med. 2026-07)*
+<a id="model-neurovfm-202607"></a>
+<details>
+<summary><b>NeuroVFM</b> — Health system learning enables generalist neuroimaging models <i>(Nat. Med. 2026-07)</i></summary>
 
 **[Health system learning enables generalist neuroimaging models](https://www.nature.com/articles/s41591-026-04497-1)**
 
-*Nat. Med.* · 2026-07 · Published · [doi:10.1038/s41591-026-04497-1](https://doi.org/10.1038/s41591-026-04497-1)
+*Nat. Med.* · 2026-07 · [doi:10.1038/s41591-026-04497-1](https://doi.org/10.1038/s41591-026-04497-1)
 
+| | |
+| --- | --- |
+| **Backbone** | 3D vision transformer |
+| **Pre-training** | `JEPA`<br>Volumetric joint-embedding predictive pretraining. |
+| **Training data** | CT and MRI neuroimaging<br>**5,240,000** volumes |
+| **Downstream tasks** | `classification`, `report generation`, `retrieval`, `triage`, `registration`<br>Generalist health-system neuroimaging. |
+| **Modalities** | `CT`, `MRI` |
+| **Code** | [github.com/MLNeurosurg/neurovfm](https://github.com/MLNeurosurg/neurovfm) |
 
-|                      |                                                                                                                     |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Backbone**         | 3D vision transformer                                                                                               |
-| **Pre-training**     | `JEPA` Volumetric joint-embedding predictive pretraining.                                                           |
-| **Training data**    | CT and MRI neuroimaging **5,240,000** volumes                                                                       |
-| **Downstream tasks** | `classification`, `report generation`, `retrieval`, `triage`, `registration` Generalist health-system neuroimaging. |
-| **Modalities**       | `CT`, `MRI`                                                                                                         |
-| **Code**             | [github.com/MLNeurosurg/neurovfm](https://github.com/MLNeurosurg/neurovfm)                                          |
+</details>
 
-
-
-
-
-
-**MARS** — Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications *(Nat. Biomed. Eng. 2026-07)*
+<a id="model-mars-202607"></a>
+<details>
+<summary><b>MARS</b> — Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications <i>(Nat. Biomed. Eng. 2026-07)</i></summary>
 
 **[Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications](https://www.nature.com/articles/s41551-026-01740-5)**
 
-*Nat. Biomed. Eng.* · 2026-07 · Published · [doi:10.1038/s41551-026-01740-5](https://doi.org/10.1038/s41551-026-01740-5)
+*Nat. Biomed. Eng.* · 2026-07 · [doi:10.1038/s41551-026-01740-5](https://doi.org/10.1038/s41551-026-01740-5)
 
+| | |
+| --- | --- |
+| **Backbone** | 3D Swin Transformer |
+| **Pre-training** | `MAE`, `contrastive learning` |
+| **Training data** | Multi-sequence MRI<br>**336,000** volumes |
+| **Downstream tasks** | `classification`, `segmentation`, `registration`, `report generation`, `prognosis`<br>Evaluated across 44 clinical tasks. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/zqiuak/MARS](https://github.com/zqiuak/MARS) |
 
-|                      |                                                                                                                        |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **Backbone**         | 3D Swin Transformer                                                                                                    |
-| **Pre-training**     | `MAE`, `contrastive learning`                                                                                          |
-| **Training data**    | Multi-sequence MRI **336,000** volumes                                                                                 |
-| **Downstream tasks** | `classification`, `segmentation`, `registration`, `report generation`, `prognosis` Evaluated across 44 clinical tasks. |
-| **Modalities**       | `MRI`                                                                                                                  |
-| **Code**             | [github.com/zqiuak/MARS](https://github.com/zqiuak/MARS)                                                               |
+</details>
 
-
-
-
-
-
-**MultitaskCognition** — Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan *(Nat. Aging 2026-05)*
+<a id="model-multitaskcognition-202605"></a>
+<details>
+<summary><b>MultitaskCognition</b> — Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan <i>(Nat. Aging 2026-05)</i></summary>
 
 **[Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan](https://doi.org/10.1038/s43587-026-01121-2)**
 
-*Nat. Aging* · 2026-05 · Published · [doi:10.1038/s43587-026-01121-2](https://doi.org/10.1038/s43587-026-01121-2)
+*Nat. Aging* · 2026-05 · [doi:10.1038/s43587-026-01121-2](https://doi.org/10.1038/s43587-026-01121-2)
 
+| | |
+| --- | --- |
+| **Backbone** | 3D U-Net, ResNet-50 and XGBoost |
+| **Pre-training** | `supervised`, `transfer learning` |
+| **Training data** | Approximately<br>**3,000** MRI studies |
+| **Downstream tasks** | `classification`, `segmentation`, `regression`, `prognosis`<br>Alzheimer’s disease outcomes from a single MRI scan. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/darenma/MultitaskCognition](https://github.com/darenma/MultitaskCognition) |
 
-|                      |                                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Backbone**         | 3D U-Net, ResNet-50 and XGBoost                                                                                  |
-| **Pre-training**     | `supervised`, `transfer learning`                                                                                |
-| **Training data**    | Approximately **3,000** MRI studies                                                                              |
-| **Downstream tasks** | `classification`, `segmentation`, `regression`, `prognosis` Alzheimer’s disease outcomes from a single MRI scan. |
-| **Modalities**       | `MRI`                                                                                                            |
-| **Code**             | [github.com/darenma/MultitaskCognition](https://github.com/darenma/MultitaskCognition)                           |
+</details>
 
-
-
-
-
-
-**FM-HCT** — 3D foundation model for generalizable disease detection in head computed tomography *(Nat. Biomed. Eng. 2026-04)*
+<a id="model-fm-hct-202604"></a>
+<details>
+<summary><b>FM-HCT</b> — 3D foundation model for generalizable disease detection in head computed tomography <i>(Nat. Biomed. Eng. 2026-04)</i></summary>
 
 **[3D foundation model for generalizable disease detection in head computed tomography](https://www.nature.com/articles/s41551-026-01668-w)**
 
-*Nat. Biomed. Eng.* · 2026-04 · Published · [doi:10.1038/s41551-026-01668-w](https://doi.org/10.1038/s41551-026-01668-w)
+*Nat. Biomed. Eng.* · 2026-04 · [doi:10.1038/s41551-026-01668-w](https://doi.org/10.1038/s41551-026-01668-w)
 
+| | |
+| --- | --- |
+| **Backbone** | Vision transformer |
+| **Pre-training** | `DINO` |
+| **Training data** | Head CT<br>**362,000** volumes |
+| **Downstream tasks** | `classification`, `retrieval`<br>Generalizable disease detection in head CT. |
+| **Modalities** | `CT` |
+| **Code** | [github.com/NYUMedML/headCT_foundation](https://github.com/NYUMedML/headCT_foundation) |
 
-|                      |                                                                                        |
-| -------------------- | -------------------------------------------------------------------------------------- |
-| **Backbone**         | Vision transformer                                                                     |
-| **Pre-training**     | `DINO`                                                                                 |
-| **Training data**    | Head CT **362,000** volumes                                                            |
-| **Downstream tasks** | `classification`, `retrieval` Generalizable disease detection in head CT.              |
-| **Modalities**       | `CT`                                                                                   |
-| **Code**             | [github.com/NYUMedML/headCT_foundation](https://github.com/NYUMedML/headCT_foundation) |
+</details>
 
-
-
-
-
-
-**NeuroFM** — Towards a general-purpose foundation model for functional MRI analysis *(Nat. Biomed. Eng. 2026-04)*
+<a id="model-neurofm-202604"></a>
+<details>
+<summary><b>NeuroFM</b> — Towards a general-purpose foundation model for functional MRI analysis <i>(Nat. Biomed. Eng. 2026-04)</i></summary>
 
 **[Towards a general-purpose foundation model for functional MRI analysis](https://www.nature.com/articles/s41551-026-01666-y)**
 
-*Nat. Biomed. Eng.* · 2026-04 · Published · [doi:10.1038/s41551-026-01666-y](https://doi.org/10.1038/s41551-026-01666-y)
+*Nat. Biomed. Eng.* · 2026-04 · [doi:10.1038/s41551-026-01666-y](https://doi.org/10.1038/s41551-026-01666-y)
 
+| | |
+| --- | --- |
+| **Backbone** | Spatiotemporal waveform Mamba |
+| **Pre-training** | `MAE` |
+| **Training data** | More than<br>**50,000** subjects and **8,650,000** fMRI frames |
+| **Downstream tasks** | `regression`, `classification`, `prognosis`<br>General-purpose functional MRI analysis. |
+| **Modalities** | `fMRI` |
+| **Code** | [github.com/CUHK-AIM-Group/NeuroSTORM](https://github.com/CUHK-AIM-Group/NeuroSTORM) |
 
-|                      |                                                                                      |
-| -------------------- | ------------------------------------------------------------------------------------ |
-| **Backbone**         | Spatiotemporal waveform Mamba                                                        |
-| **Pre-training**     | `MAE`                                                                                |
-| **Training data**    | More than **50,000** subjects and **8,650,000** fMRI frames                          |
-| **Downstream tasks** | `regression`, `classification`, `prognosis` General-purpose functional MRI analysis. |
-| **Modalities**       | `fMRI`                                                                               |
-| **Code**             | [github.com/CUHK-AIM-Group/NeuroSTORM](https://github.com/CUHK-AIM-Group/NeuroSTORM) |
+</details>
 
-
-
-
-
-
-**TRIBEv2** — A foundation model of vision, audition, and language for in-silico neuroscience *(arXiv 2026-03)*
+<a id="model-tribev2-202603"></a>
+<details>
+<summary><b>TRIBEv2</b> — A foundation model of vision, audition, and language for in-silico neuroscience <i>(arXiv 2026-03)</i></summary>
 
 **[A foundation model of vision, audition, and language for in-silico neuroscience](https://ai.meta.com/research/publications/a-foundation-model-of-vision-audition-and-language-for-in-silico-neuroscience/)**
 
-*arXiv* · 2026-03 · Preprint
+*arXiv* · 2026-03
 
+| | |
+| --- | --- |
+| **Backbone** | V-JEPA 2, wav2vec and Llama |
+| **Pre-training** | Multimodal representation learning |
+| **Training data** | Multiple datasets; numeric scale not recorded |
+| **Downstream tasks** | `regression`<br>Maps vision, audio and language stimuli to predicted brain voxels. |
+| **Modalities** | `fMRI`, `vision`, `audio`, `text` |
+| **Code** | [github.com/facebookresearch/tribev2](https://github.com/facebookresearch/tribev2) |
 
-|                      |                                                                                    |
-| -------------------- | ---------------------------------------------------------------------------------- |
-| **Backbone**         | V-JEPA 2, wav2vec and Llama                                                        |
-| **Pre-training**     | Multimodal representation learning                                                 |
-| **Training data**    | Multiple datasets; numeric scale not recorded                                      |
-| **Downstream tasks** | `regression` Maps vision, audio and language stimuli to predicted brain voxels.    |
-| **Modalities**       | `fMRI`, `vision`, `audio`, `text`                                                  |
-| **Code**             | [github.com/facebookresearch/tribev2](https://github.com/facebookresearch/tribev2) |
+</details>
 
-
-
-
-
-
-**Merlin** — Merlin: a computed tomography vision–language foundation model and dataset *(Nature 2026-03)*
+<a id="model-merlin-202603"></a>
+<details>
+<summary><b>Merlin</b> — Merlin: a computed tomography vision–language foundation model and dataset <i>(Nature 2026-03)</i></summary>
 
 **[Merlin: a computed tomography vision–language foundation model and dataset](https://www.nature.com/articles/s41586-026-10181-8)**
 
-*Nature* · 2026-03 · Updated · [doi:10.1038/s41586-026-10181-8](https://doi.org/10.1038/s41586-026-10181-8)
+*Nature* · 2026-03 · [doi:10.1038/s41586-026-10181-8](https://doi.org/10.1038/s41586-026-10181-8)
 
-
-|                      |                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------- |
-| **Backbone**         | ResNet vision encoder and Longformer text encoder                               |
-| **Pre-training**     | `CLIP`                                                                          |
-| **Training data**    | CT volumes paired with clinical text **25,500** CT volumes                      |
+| | |
+| --- | --- |
+| **Backbone** | ResNet vision encoder and Longformer text encoder |
+| **Pre-training** | `CLIP` |
+| **Training data** | CT volumes paired with clinical text<br>**25,500** CT volumes |
 | **Downstream tasks** | `classification`, `segmentation`, `retrieval`, `report generation`, `prognosis` |
-| **Modalities**       | `CT`, `text`                                                                    |
-| **Code**             | [github.com/StanfordMIMI/Merlin](https://github.com/StanfordMIMI/Merlin)        |
-| **Dataset**          | [github.com/StanfordMIMI/Merlin](https://github.com/StanfordMIMI/Merlin)        |
+| **Modalities** | `CT`, `text` |
+| **Code** | [github.com/StanfordMIMI/Merlin](https://github.com/StanfordMIMI/Merlin) |
+| **Dataset** | [github.com/StanfordMIMI/Merlin](https://github.com/StanfordMIMI/Merlin) |
 
+</details>
 
-
-
-
-
-**Thymus-IO** — Thymic health and immunotherapy outcomes in patients with cancer *(Nature 2026-03)*
+<a id="model-thymus-io-202603"></a>
+<details>
+<summary><b>Thymus-IO</b> — Thymic health and immunotherapy outcomes in patients with cancer <i>(Nature 2026-03)</i></summary>
 
 **[Thymic health and immunotherapy outcomes in patients with cancer](https://www.nature.com/articles/s41586-026-10243-x)**
 
-*Nature* · 2026-03 · Published · [doi:10.1038/s41586-026-10243-x](https://doi.org/10.1038/s41586-026-10243-x)
+*Nature* · 2026-03 · [doi:10.1038/s41586-026-10243-x](https://doi.org/10.1038/s41586-026-10243-x)
 
+| | |
+| --- | --- |
+| **Backbone** | U-Net and 3D ResNet-50 |
+| **Pre-training** | `SwAV` |
+| **Training data** | **5,700** CT volumes |
+| **Downstream tasks** | `classification`, `prognosis`<br>Associates thymic health with immunotherapy outcomes. |
+| **Modalities** | `CT` |
 
-|                      |                                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------- |
-| **Backbone**         | U-Net and 3D ResNet-50                                                              |
-| **Pre-training**     | `SwAV`                                                                              |
-| **Training data**    | **5,700** CT volumes                                                                |
-| **Downstream tasks** | `classification`, `prognosis` Associates thymic health with immunotherapy outcomes. |
-| **Modalities**       | `CT`                                                                                |
+</details>
 
-
-
-
-
-
-**Thymus-Adult** — Thymic health consequences in adults *(Nature 2026-03)*
+<a id="model-thymus-adult-202603"></a>
+<details>
+<summary><b>Thymus-Adult</b> — Thymic health consequences in adults <i>(Nature 2026-03)</i></summary>
 
 **[Thymic health consequences in adults](https://www.nature.com/articles/s41586-026-10242-y)**
 
-*Nature* · 2026-03 · Published · [doi:10.1038/s41586-026-10242-y](https://doi.org/10.1038/s41586-026-10242-y)
+*Nature* · 2026-03 · [doi:10.1038/s41586-026-10242-y](https://doi.org/10.1038/s41586-026-10242-y)
 
+| | |
+| --- | --- |
+| **Backbone** | U-Net and 3D ResNet-50 |
+| **Pre-training** | `SwAV` |
+| **Training data** | **5,700** CT volumes |
+| **Downstream tasks** | `classification`<br>Assesses thymic health in adults. |
+| **Modalities** | `CT` |
 
-|                      |                                                    |
-| -------------------- | -------------------------------------------------- |
-| **Backbone**         | U-Net and 3D ResNet-50                             |
-| **Pre-training**     | `SwAV`                                             |
-| **Training data**    | **5,700** CT volumes                               |
-| **Downstream tasks** | `classification` Assesses thymic health in adults. |
-| **Modalities**       | `CT`                                               |
+</details>
 
-
-
-
-
-
-**OMAFound** — A foundation model for breast and lung cancer screening using non-contrast computed tomography *(Nat. Health 2026-02)*
+<a id="model-omafound-202602"></a>
+<details>
+<summary><b>OMAFound</b> — A foundation model for breast and lung cancer screening using non-contrast computed tomography <i>(Nat. Health 2026-02)</i></summary>
 
 **[A foundation model for breast and lung cancer screening using non-contrast computed tomography](https://doi.org/10.1038/s44360-026-00055-8)**
 
-*Nat. Health* · 2026-02 · Published · [doi:10.1038/s44360-026-00055-8](https://doi.org/10.1038/s44360-026-00055-8)
+*Nat. Health* · 2026-02 · [doi:10.1038/s44360-026-00055-8](https://doi.org/10.1038/s44360-026-00055-8)
 
+| | |
+| --- | --- |
+| **Backbone** | SwinUNETR-V2 encoder |
+| **Pre-training** | `self-supervised`<br>Rotation, reconstruction and contrastive objectives. |
+| **Training data** | Ten CT datasets<br>**325,197** CT volumes · **151,386** patients |
+| **Downstream tasks** | `classification`<br>Breast and lung cancer screening from non-contrast CT. |
+| **Modalities** | `CT` |
+| **Code** | [github.com/Qian-IMMULab/OMAFound](https://github.com/Qian-IMMULab/OMAFound) |
 
-|                      |                                                                              |
-| -------------------- | ---------------------------------------------------------------------------- |
-| **Backbone**         | SwinUNETR-V2 encoder                                                         |
-| **Pre-training**     | `self-supervised` Rotation, reconstruction and contrastive objectives.       |
-| **Training data**    | Ten CT datasets **325,197** CT volumes · **151,386** patients                |
-| **Downstream tasks** | `classification` Breast and lung cancer screening from non-contrast CT.      |
-| **Modalities**       | `CT`                                                                         |
-| **Code**             | [github.com/Qian-IMMULab/OMAFound](https://github.com/Qian-IMMULab/OMAFound) |
+</details>
 
-
-
-
-
-
-**CMR Transformer** — A generalizable deep learning system for cardiac MRI *(Nat. Biomed. Eng. 2026-02)*
+<a id="model-cmr-transformer-202602"></a>
+<details>
+<summary><b>CMR Transformer</b> — A generalizable deep learning system for cardiac MRI <i>(Nat. Biomed. Eng. 2026-02)</i></summary>
 
 **[A generalizable deep learning system for cardiac MRI](https://www.nature.com/articles/s41551-026-01637-3)**
 
-*Nat. Biomed. Eng.* · 2026-02 · Published · [doi:10.1038/s41551-026-01637-3](https://doi.org/10.1038/s41551-026-01637-3)
+*Nat. Biomed. Eng.* · 2026-02 · [doi:10.1038/s41551-026-01637-3](https://doi.org/10.1038/s41551-026-01637-3)
 
+| | |
+| --- | --- |
+| **Backbone** | Multiscale vision transformer and BERT text encoder |
+| **Pre-training** | `InfoNCE`, `contrastive`<br>Image-report contrastive learning. |
+| **Training data** | Cardiac MRI with paired reports Approximately<br>**21,000** scans |
+| **Downstream tasks** | `regression`, `classification`<br>Left-ventricular ejection fraction and 39 cardiovascular conditions. |
+| **Modalities** | `MRI`, `text` |
+| **Code** | [github.com/rohanshad/cmr_transformer](https://github.com/rohanshad/cmr_transformer) |
 
-|                      |                                                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------- |
-| **Backbone**         | Multiscale vision transformer and BERT text encoder                                                 |
-| **Pre-training**     | `InfoNCE`, `contrastive` Image-report contrastive learning.                                         |
-| **Training data**    | Cardiac MRI with paired reports Approximately **21,000** scans                                      |
-| **Downstream tasks** | `regression`, `classification` Left-ventricular ejection fraction and 39 cardiovascular conditions. |
-| **Modalities**       | `MRI`, `text`                                                                                       |
-| **Code**             | [github.com/rohanshad/cmr_transformer](https://github.com/rohanshad/cmr_transformer)                |
+</details>
 
-
-
-
-
-
-**BrainIAC** — A generalizable foundation model for analysis of human brain MRI *(Nat. Neurosci. 2026-02)*
+<a id="model-brainiac-202602"></a>
+<details>
+<summary><b>BrainIAC</b> — A generalizable foundation model for analysis of human brain MRI <i>(Nat. Neurosci. 2026-02)</i></summary>
 
 **[A generalizable foundation model for analysis of human brain MRI](https://www.nature.com/articles/s41593-026-02202-6)**
 
-*Nat. Neurosci.* · 2026-02 · Published · [doi:10.1038/s41593-026-02202-6](https://doi.org/10.1038/s41593-026-02202-6)
+*Nat. Neurosci.* · 2026-02 · [doi:10.1038/s41593-026-02202-6](https://doi.org/10.1038/s41593-026-02202-6)
 
+| | |
+| --- | --- |
+| **Backbone** | ViT-B |
+| **Pre-training** | `SimCLR` |
+| **Training data** | **32,000** MRI scans |
+| **Downstream tasks** | `classification`, `regression`, `segmentation`, `prognosis`<br>Generalizable analysis of brain MRI. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/AIM-KannLab/BrainIAC](https://github.com/AIM-KannLab/BrainIAC) |
 
-|                      |                                                                                                  |
-| -------------------- | ------------------------------------------------------------------------------------------------ |
-| **Backbone**         | ViT-B                                                                                            |
-| **Pre-training**     | `SimCLR`                                                                                         |
-| **Training data**    | **32,000** MRI scans                                                                             |
-| **Downstream tasks** | `classification`, `regression`, `segmentation`, `prognosis` Generalizable analysis of brain MRI. |
-| **Modalities**       | `MRI`                                                                                            |
-| **Code**             | [github.com/AIM-KannLab/BrainIAC](https://github.com/AIM-KannLab/BrainIAC)                       |
+</details>
 
-
-
-
-
-
-**CT-CLIP / CT-CHAT** — Generalist foundation models from a multimodal dataset for 3D computed tomography *(Nat. Biomed. Eng. 2026-02)*
+<a id="model-ct-clip-ct-chat-202602"></a>
+<details>
+<summary><b>CT-CLIP / CT-CHAT</b> — Generalist foundation models from a multimodal dataset for 3D computed tomography <i>(Nat. Biomed. Eng. 2026-02)</i></summary>
 
 **[Generalist foundation models from a multimodal dataset for 3D computed tomography](https://www.nature.com/articles/s41551-025-01599-y)**
 
-*Nat. Biomed. Eng.* · 2026-02 · Published · [doi:10.1038/s41551-025-01599-y](https://doi.org/10.1038/s41551-025-01599-y)
+*Nat. Biomed. Eng.* · 2026-02 · [doi:10.1038/s41551-025-01599-y](https://doi.org/10.1038/s41551-025-01599-y)
 
+| | |
+| --- | --- |
+| **Backbone** | CT-ViT |
+| **Pre-training** | `CLIP`<br>Contrastive alignment of CT volumes and radiology reports. |
+| **Training data** | CT-RATE<br>**25,692** CT volumes |
+| **Downstream tasks** | `classification`, `retrieval`, `VQA`<br>Generalist 3D CT vision-language analysis and dialogue. |
+| **Modalities** | `CT`, `text` |
+| **Code** | [github.com/ibrahimethemhamamci/CT-CLIP](https://github.com/ibrahimethemhamamci/CT-CLIP) |
 
-|                      |                                                                                              |
-| -------------------- | -------------------------------------------------------------------------------------------- |
-| **Backbone**         | CT-ViT                                                                                       |
-| **Pre-training**     | `CLIP` Contrastive alignment of CT volumes and radiology reports.                            |
-| **Training data**    | CT-RATE **25,692** CT volumes                                                                |
-| **Downstream tasks** | `classification`, `retrieval`, `VQA` Generalist 3D CT vision-language analysis and dialogue. |
-| **Modalities**       | `CT`, `text`                                                                                 |
-| **Code**             | [github.com/ibrahimethemhamamci/CT-CLIP](https://github.com/ibrahimethemhamamci/CT-CLIP)     |
+</details>
 
-
-
-
-
-
-**PRIMA** — Learning neuroimaging models from health system-scale data *(Nat. Biomed. Eng. 2026-02)*
+<a id="model-prima-202602"></a>
+<details>
+<summary><b>PRIMA</b> — Learning neuroimaging models from health system-scale data <i>(Nat. Biomed. Eng. 2026-02)</i></summary>
 
 **[Learning neuroimaging models from health system-scale data](https://www.nature.com/articles/s41551-025-01608-0)**
 
-*Nat. Biomed. Eng.* · 2026-02 · Published · [doi:10.1038/s41551-025-01608-0](https://doi.org/10.1038/s41551-025-01608-0)
+*Nat. Biomed. Eng.* · 2026-02 · [doi:10.1038/s41551-025-01608-0](https://doi.org/10.1038/s41551-025-01608-0)
 
+| | |
+| --- | --- |
+| **Backbone** | Hierarchical vision transformer |
+| **Pre-training** | `CLIP` |
+| **Training data** | **221,000** MRI studies · **5,600,000** sequences |
+| **Downstream tasks** | `classification`, `triage`, `regression`<br>Prediction of 52 radiologic diagnoses. |
+| **Modalities** | `MRI`, `text` |
 
-|                      |                                                                                 |
-| -------------------- | ------------------------------------------------------------------------------- |
-| **Backbone**         | Hierarchical vision transformer                                                 |
-| **Pre-training**     | `CLIP`                                                                          |
-| **Training data**    | **221,000** MRI studies · **5,600,000** sequences                               |
-| **Downstream tasks** | `classification`, `triage`, `regression` Prediction of 52 radiologic diagnoses. |
-| **Modalities**       | `MRI`, `text`                                                                   |
+</details>
 
-
-
-
-
-
-**MAOSS** — Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease *(Nat. Commun. 2026-02)*
+<a id="model-maoss-202602"></a>
+<details>
+<summary><b>MAOSS</b> — Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease <i>(Nat. Commun. 2026-02)</i></summary>
 
 **[Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease](https://www.nature.com/articles/s41467-026-68414-3)**
 
-*Nat. Commun.* · 2026-02 · Published · [doi:10.1038/s41467-026-68414-3](https://doi.org/10.1038/s41467-026-68414-3)
+*Nat. Commun.* · 2026-02 · [doi:10.1038/s41467-026-68414-3](https://doi.org/10.1038/s41467-026-68414-3)
 
+| | |
+| --- | --- |
+| **Backbone** | 3D ResNet-34 and ViLT |
+| **Pre-training** | Not recorded |
+| **Training data** | Multisite imaging data and information from 226 publications |
+| **Downstream tasks** | `classification`, `prognosis`<br>Screening, staging and progression-risk stratification of steatotic liver disease. |
+| **Modalities** | `CT`, `text` |
+| **Code** | [github.com/YGOX/MAOSS](https://github.com/YGOX/MAOSS) |
 
-|                      |                                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Backbone**         | 3D ResNet-34 and ViLT                                                                                            |
-| **Pre-training**     | Not recorded                                                                                                     |
-| **Training data**    | Multisite imaging data and information from 226 publications                                                     |
-| **Downstream tasks** | `classification`, `prognosis` Screening, staging and progression-risk stratification of steatotic liver disease. |
-| **Modalities**       | `CT`, `text`                                                                                                     |
-| **Code**             | [github.com/YGOX/MAOSS](https://github.com/YGOX/MAOSS)                                                           |
+</details>
 
-
-
-
-
-
-**AFLoc** — A multimodal vision–language model for generalizable annotation-free pathology localization *(Nat. Biomed. Eng. 2026-01)*
+<a id="model-afloc-202601"></a>
+<details>
+<summary><b>AFLoc</b> — A multimodal vision–language model for generalizable annotation-free pathology localization <i>(Nat. Biomed. Eng. 2026-01)</i></summary>
 
 **[A multimodal vision–language model for generalizable annotation-free pathology localization](https://www.nature.com/articles/s41551-025-01574-7)**
 
-*Nat. Biomed. Eng.* · 2026-01 · Published · [doi:10.1038/s41551-025-01574-7](https://doi.org/10.1038/s41551-025-01574-7)
+*Nat. Biomed. Eng.* · 2026-01 · [doi:10.1038/s41551-025-01574-7](https://doi.org/10.1038/s41551-025-01574-7)
 
+| | |
+| --- | --- |
+| **Backbone** | ResNet and BioClinicalBERT |
+| **Pre-training** | `CLIP` |
+| **Training data** | MIMIC-CXR |
+| **Downstream tasks** | `localization`, `classification`<br>Annotation-free pathology localization. |
+| **Modalities** | `X-ray`, `text` |
+| **Code** | [github.com/YH0517/AFLoc](https://github.com/YH0517/AFLoc) |
+| **Dataset** | [physionet.org/content/mimic-cxr](https://physionet.org/content/mimic-cxr/) |
 
-|                      |                                                                             |
-| -------------------- | --------------------------------------------------------------------------- |
-| **Backbone**         | ResNet and BioClinicalBERT                                                  |
-| **Pre-training**     | `CLIP`                                                                      |
-| **Training data**    | MIMIC-CXR                                                                   |
-| **Downstream tasks** | `localization`, `classification` Annotation-free pathology localization.    |
-| **Modalities**       | `X-ray`, `text`                                                             |
-| **Code**             | [github.com/YH0517/AFLoc](https://github.com/YH0517/AFLoc)                  |
-| **Dataset**          | [physionet.org/content/mimic-cxr](https://physionet.org/content/mimic-cxr/) |
+</details>
 
-
-
-
-
-
-**deepmriprep** — deepmriprep: voxel-based morphometry preprocessing via deep neural networks *(Nat. Comput. Sci. 2026-01)*
+<a id="model-deepmriprep-202601"></a>
+<details>
+<summary><b>deepmriprep</b> — deepmriprep: voxel-based morphometry preprocessing via deep neural networks <i>(Nat. Comput. Sci. 2026-01)</i></summary>
 
 **[deepmriprep: voxel-based morphometry preprocessing via deep neural networks](https://www.nature.com/articles/s43588-026-00953-7)**
 
-*Nat. Comput. Sci.* · 2026-01 · Published · [doi:10.1038/s43588-026-00953-7](https://doi.org/10.1038/s43588-026-00953-7)
+*Nat. Comput. Sci.* · 2026-01 · [doi:10.1038/s43588-026-00953-7](https://doi.org/10.1038/s43588-026-00953-7)
 
+| | |
+| --- | --- |
+| **Backbone** | 3D U-Net |
+| **Pre-training** | Not recorded |
+| **Training data** | **685** MRI scans |
+| **Downstream tasks** | `preprocessing`<br>Deep-learning voxel-based morphometry preprocessing. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/wwu-mmll/deepmriprep-train](https://github.com/wwu-mmll/deepmriprep-train) |
 
-|                      |                                                                                        |
-| -------------------- | -------------------------------------------------------------------------------------- |
-| **Backbone**         | 3D U-Net                                                                               |
-| **Pre-training**     | Not recorded                                                                           |
-| **Training data**    | **685** MRI scans                                                                      |
-| **Downstream tasks** | `preprocessing` Deep-learning voxel-based morphometry preprocessing.                   |
-| **Modalities**       | `MRI`                                                                                  |
-| **Code**             | [github.com/wwu-mmll/deepmriprep-train](https://github.com/wwu-mmll/deepmriprep-train) |
+</details>
 
-
-
-
-
-
-**FOMO25** — From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models *(arXiv 2026-01)*
+<a id="model-fomo25-202601"></a>
+<details>
+<summary><b>FOMO25</b> — From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models <i>(arXiv 2026-01)</i></summary>
 
 **[From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models](https://arxiv.org/abs/2601.13166)**
 
-*arXiv* · 2026-01 · Preprint · [arXiv:2601.13166](https://arxiv.org/abs/2601.13166)
+*arXiv* · 2026-01 · [arXiv:2601.13166](https://arxiv.org/abs/2601.13166)
 
+| | |
+| --- | --- |
+| **Backbone** | CNN U-Net |
+| **Pre-training** | `MAE` |
+| **Training data** | **115,000 + 61,000** MRI volumes |
+| **Downstream tasks** | `segmentation`, `classification`, `regression`<br>SSL3D and FOMO25 challenge tasks. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/jbanusco/BrainFM4Challenges](https://github.com/jbanusco/BrainFM4Challenges) |
 
-|                      |                                                                                          |
-| -------------------- | ---------------------------------------------------------------------------------------- |
-| **Backbone**         | CNN U-Net                                                                                |
-| **Pre-training**     | `MAE`                                                                                    |
-| **Training data**    | **115,000 + 61,000** MRI volumes                                                         |
-| **Downstream tasks** | `segmentation`, `classification`, `regression` SSL3D and FOMO25 challenge tasks.         |
-| **Modalities**       | `MRI`                                                                                    |
-| **Code**             | [github.com/jbanusco/BrainFM4Challenges](https://github.com/jbanusco/BrainFM4Challenges) |
+</details>
 
-
-
-
-
-
-**VoCo** — Large-scale 3D medical image pre-training with geometric context priors *(IEEE TPAMI 2025-12)*
+<a id="model-voco-202512"></a>
+<details>
+<summary><b>VoCo</b> — Large-scale 3D medical image pre-training with geometric context priors <i>(IEEE TPAMI 2025-12)</i></summary>
 
 **[Large-scale 3D medical image pre-training with geometric context priors](https://doi.org/10.1109/tpami.2025.3639593)**
 
-*IEEE TPAMI* · 2025-12 · Published · [doi:10.1109/TPAMI.2025.3639593](https://doi.org/10.1109/tpami.2025.3639593)
+*IEEE TPAMI* · 2025-12 · [doi:10.1109/TPAMI.2025.3639593](https://doi.org/10.1109/tpami.2025.3639593)
 
+| | |
+| --- | --- |
+| **Backbone** | SwinUNETR |
+| **Pre-training** | `VoCo`, `contrastive learning`<br>Volume contrastive learning with geometric context priors. |
+| **Training data** | PreCT-160K<br>**160,000** CT volumes |
+| **Downstream tasks** | `segmentation`, `classification`, `regression`, `vision-language modeling`<br>Evaluated on more than 50 tasks. |
+| **Modalities** | `CT` |
+| **Code** | [github.com/Luffy03/Large-Scale-Medical](https://github.com/Luffy03/Large-Scale-Medical) |
+| **Dataset** | [huggingface.co/datasets/Luffy503/PreCT-160K](https://huggingface.co/datasets/Luffy503/PreCT-160K) |
+| **PDF name** | `VoCo - Large-Scale 3D Medical Image Pre-Training With Geometric Context Priors.pdf` |
 
-|                      |                                                                                                             |
-| -------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Backbone**         | SwinUNETR                                                                                                   |
-| **Pre-training**     | `VoCo`, `contrastive learning` Volume contrastive learning with geometric context priors.                   |
-| **Training data**    | PreCT-160K **160,000** CT volumes                                                                           |
-| **Downstream tasks** | `segmentation`, `classification`, `regression`, `vision-language modeling` Evaluated on more than 50 tasks. |
-| **Modalities**       | `CT`                                                                                                        |
-| **Code**             | [github.com/Luffy03/Large-Scale-Medical](https://github.com/Luffy03/Large-Scale-Medical)                    |
-| **Dataset**          | [huggingface.co/datasets/Luffy503/PreCT-160K](https://huggingface.co/datasets/Luffy503/PreCT-160K)          |
-| **PDF name**         | `VoCo - Large-Scale 3D Medical Image Pre-Training With Geometric Context Priors.pdf`                        |
+</details>
 
-
-
-
-
-
-**TAP-CT** — TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models *(arXiv 2025-12)*
+<a id="model-tap-ct-202512"></a>
+<details>
+<summary><b>TAP-CT</b> — TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models <i>(arXiv 2025-12)</i></summary>
 
 **[TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models](https://arxiv.org/abs/2512.00872)**
 
-*arXiv* · 2025-12 · Preprint · [arXiv:2512.00872](https://arxiv.org/abs/2512.00872)
+*arXiv* · 2025-12 · [arXiv:2512.00872](https://arxiv.org/abs/2512.00872)
 
+| | |
+| --- | --- |
+| **Backbone** | 3D vision transformer |
+| **Pre-training** | `DINOv2` |
+| **Training data** | **105,000** CT volumes |
+| **Downstream tasks** | `segmentation`, `classification`<br>Task-agnostic 3D CT foundation-model suite. |
+| **Modalities** | `CT` |
+| **Weights** | [huggingface.co/fomofo/tap-ct-b-3d](https://huggingface.co/fomofo/tap-ct-b-3d) |
+| **PDF name** | `TAP-CT - 3D Task-Agnostic Pretraining of CT Foundation Models.pdf` |
 
-|                      |                                                                                |
-| -------------------- | ------------------------------------------------------------------------------ |
-| **Backbone**         | 3D vision transformer                                                          |
-| **Pre-training**     | `DINOv2`                                                                       |
-| **Training data**    | **105,000** CT volumes                                                         |
-| **Downstream tasks** | `segmentation`, `classification` Task-agnostic 3D CT foundation-model suite.   |
-| **Modalities**       | `CT`                                                                           |
-| **Weights**          | [huggingface.co/fomofo/tap-ct-b-3d](https://huggingface.co/fomofo/tap-ct-b-3d) |
-| **PDF name**         | `TAP-CT - 3D Task-Agnostic Pretraining of CT Foundation Models.pdf`            |
+</details>
 
-
-
-
-
-
-**AnyMC3D** — Revisiting 2D foundation models for scalable 3D medical image classification *(arXiv 2025-12)*
+<a id="model-anymc3d-202512"></a>
+<details>
+<summary><b>AnyMC3D</b> — Revisiting 2D foundation models for scalable 3D medical image classification <i>(arXiv 2025-12)</i></summary>
 
 **[Revisiting 2D foundation models for scalable 3D medical image classification](https://arxiv.org/abs/2512.12887)**
 
-*arXiv* · 2025-12 · Preprint · [arXiv:2512.12887](https://arxiv.org/abs/2512.12887)
+*arXiv* · 2025-12 · [arXiv:2512.12887](https://arxiv.org/abs/2512.12887)
 
+| | |
+| --- | --- |
+| **Backbone** | DINOv2 and DINOv3 backbones with lightweight task plugins |
+| **Pre-training** | `DINOv2`, `DINOv3` |
+| **Training data** | Numeric scale not recorded |
+| **Downstream tasks** | `classification`<br>Scalable evaluation across 12 three-dimensional classification tasks. |
+| **Modalities** | `CT`, `MRI` |
 
-|                      |                                                                                        |
-| -------------------- | -------------------------------------------------------------------------------------- |
-| **Backbone**         | DINOv2 and DINOv3 backbones with lightweight task plugins                              |
-| **Pre-training**     | `DINOv2`, `DINOv3`                                                                     |
-| **Training data**    | Numeric scale not recorded                                                             |
-| **Downstream tasks** | `classification` Scalable evaluation across 12 three-dimensional classification tasks. |
-| **Modalities**       | `CT`, `MRI`                                                                            |
+</details>
 
-
-
-
-
-
-**Pillar-0** — Pillar-0: a new frontier for radiology foundation models *(arXiv 2025-11)*
+<a id="model-pillar-0-202511"></a>
+<details>
+<summary><b>Pillar-0</b> — Pillar-0: a new frontier for radiology foundation models <i>(arXiv 2025-11)</i></summary>
 
 **[Pillar-0: a new frontier for radiology foundation models](https://arxiv.org/abs/2511.17803)**
 
-*arXiv* · 2025-11 · Preprint · [arXiv:2511.17803](https://arxiv.org/abs/2511.17803)
+*arXiv* · 2025-11 · [arXiv:2511.17803](https://arxiv.org/abs/2511.17803)
 
+| | |
+| --- | --- |
+| **Backbone** | Atlas |
+| **Pre-training** | `contrastive`, `vision-language`<br>CLIP-like radiology pretraining. |
+| **Training data** | Abdomen-pelvis, chest and head CT plus breast MRI<br>**155,292** volumes |
+| **Downstream tasks** | `classification`, `prognosis`<br>Best-performing model on 319 of 366 RATE findings. |
+| **Modalities** | `CT`, `MRI`, `text` |
+| **Code** | [github.com/YalaLab/pillar-pretrain](https://github.com/YalaLab/pillar-pretrain) |
+| **PDF name** | `Pillar-0 - A New Frontier for Radiology Foundation Models.pdf` |
 
-|                      |                                                                                  |
-| -------------------- | -------------------------------------------------------------------------------- |
-| **Backbone**         | Atlas                                                                            |
-| **Pre-training**     | `contrastive`, `vision-language` CLIP-like radiology pretraining.                |
-| **Training data**    | Abdomen-pelvis, chest and head CT plus breast MRI **155,292** volumes            |
-| **Downstream tasks** | `classification`, `prognosis` Best-performing model on 319 of 366 RATE findings. |
-| **Modalities**       | `CT`, `MRI`, `text`                                                              |
-| **Code**             | [github.com/YalaLab/pillar-pretrain](https://github.com/YalaLab/pillar-pretrain) |
-| **PDF name**         | `Pillar-0 - A New Frontier for Radiology Foundation Models.pdf`                  |
+</details>
 
-
-
-
-
-
-**SPECTRE** — Scaling self-supervised and cross-modal pretraining for volumetric CT transformers *(CVPR 2026 2025-11)*
+<a id="model-spectre-202511"></a>
+<details>
+<summary><b>SPECTRE</b> — Scaling self-supervised and cross-modal pretraining for volumetric CT transformers <i>(CVPR 2026 2025-11)</i></summary>
 
 **[Scaling self-supervised and cross-modal pretraining for volumetric CT transformers](https://arxiv.org/abs/2511.17209)**
 
-*CVPR 2026* · 2025-11 · Accepted · [arXiv:2511.17209](https://arxiv.org/abs/2511.17209)
+*CVPR 2026* · 2025-11 · [arXiv:2511.17209](https://arxiv.org/abs/2511.17209)
 
+| | |
+| --- | --- |
+| **Backbone** | Local and global 3D vision transformers |
+| **Pre-training** | `DINOv3`, `SigLIP`<br>Self-supervised and cross-modal pretraining. |
+| **Training data** | **230,000** CT volumes |
+| **Downstream tasks** | `classification`, `segmentation`, `retrieval`<br>Scaling study for volumetric CT. |
+| **Modalities** | `CT`, `text` |
+| **Code** | [github.com/cclaess/SPECTRE](https://github.com/cclaess/SPECTRE) |
 
-|                      |                                                                                |
-| -------------------- | ------------------------------------------------------------------------------ |
-| **Backbone**         | Local and global 3D vision transformers                                        |
-| **Pre-training**     | `DINOv3`, `SigLIP` Self-supervised and cross-modal pretraining.                |
-| **Training data**    | **230,000** CT volumes                                                         |
-| **Downstream tasks** | `classification`, `segmentation`, `retrieval` Scaling study for volumetric CT. |
-| **Modalities**       | `CT`, `text`                                                                   |
-| **Code**             | [github.com/cclaess/SPECTRE](https://github.com/cclaess/SPECTRE)               |
+</details>
 
-
-
-
-
-
-**BrainFound** — Towards generalisable foundation models for brain MRI *(arXiv 2025-10)*
+<a id="model-brainfound-202510"></a>
+<details>
+<summary><b>BrainFound</b> — Towards generalisable foundation models for brain MRI <i>(arXiv 2025-10)</i></summary>
 
 **[Towards generalisable foundation models for brain MRI](https://arxiv.org/abs/2510.23415)**
 
-*arXiv* · 2025-10 · Preprint · [arXiv:2510.23415](https://arxiv.org/abs/2510.23415)
+*arXiv* · 2025-10 · [arXiv:2510.23415](https://arxiv.org/abs/2510.23415)
 
+| | |
+| --- | --- |
+| **Backbone** | ViT-L |
+| **Pre-training** | `DINOv2` |
+| **Training data** | **10,000** MRI volumes |
+| **Downstream tasks** | `classification`<br>Neurodegeneration classification and tumour grading. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/Moona-Mazher/BrainFound](https://github.com/Moona-Mazher/BrainFound) |
 
-|                      |                                                                                  |
-| -------------------- | -------------------------------------------------------------------------------- |
-| **Backbone**         | ViT-L                                                                            |
-| **Pre-training**     | `DINOv2`                                                                         |
-| **Training data**    | **10,000** MRI volumes                                                           |
-| **Downstream tasks** | `classification` Neurodegeneration classification and tumour grading.            |
-| **Modalities**       | `MRI`                                                                            |
-| **Code**             | [github.com/Moona-Mazher/BrainFound](https://github.com/Moona-Mazher/BrainFound) |
+</details>
 
-
-
-
-
-
-**MRI-PTPCa** — An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer *(Nat. Cancer 2025-09)*
+<a id="model-mri-ptpca-202509"></a>
+<details>
+<summary><b>MRI-PTPCa</b> — An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer <i>(Nat. Cancer 2025-09)</i></summary>
 
 **[An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer](https://www.nature.com/articles/s43018-025-01041-x)**
 
-*Nat. Cancer* · 2025-09 · Published · [doi:10.1038/s43018-025-01041-x](https://doi.org/10.1038/s43018-025-01041-x)
+*Nat. Cancer* · 2025-09 · [doi:10.1038/s43018-025-01041-x](https://doi.org/10.1038/s43018-025-01041-x)
 
+| | |
+| --- | --- |
+| **Backbone** | CNN and vision transformer |
+| **Pre-training** | `BYOL` |
+| **Training data** | Numeric scale not recorded |
+| **Downstream tasks** | `classification`, `grading`<br>Non-invasive prostate-cancer diagnosis and grading. |
+| **Modalities** | `MRI`, `histopathology` |
+| **Code** | [github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer](https://github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer) |
 
-|                      |                                                                                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Backbone**         | CNN and vision transformer                                                                                                                                       |
-| **Pre-training**     | `BYOL`                                                                                                                                                           |
-| **Training data**    | Numeric scale not recorded                                                                                                                                       |
-| **Downstream tasks** | `classification`, `grading` Non-invasive prostate-cancer diagnosis and grading.                                                                                  |
-| **Modalities**       | `MRI`, `histopathology`                                                                                                                                          |
-| **Code**             | [github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer](https://github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer) |
+</details>
 
-
-
-
-
-
-**Curia** — Curia: a multi-modal foundation model for radiology *(arXiv 2025-08)*
+<a id="model-curia-202508"></a>
+<details>
+<summary><b>Curia</b> — Curia: a multi-modal foundation model for radiology <i>(arXiv 2025-08)</i></summary>
 
 **[Curia: a multi-modal foundation model for radiology](https://arxiv.org/abs/2509.06830)**
 
-*arXiv* · 2025-08 · Preprint · [arXiv:2509.06830](https://arxiv.org/abs/2509.06830)
+*arXiv* · 2025-08 · [arXiv:2509.06830](https://arxiv.org/abs/2509.06830)
 
+| | |
+| --- | --- |
+| **Backbone** | ViT-B |
+| **Pre-training** | `DINOv2` |
+| **Training data** | **164,000,000** CT and **64,000,000** MRI DICOM images |
+| **Downstream tasks** | General-purpose multimodal radiology representation learning |
+| **Modalities** | `CT`, `MRI` |
+| **Code** | [github.com/raidium-med/curia](https://github.com/raidium-med/curia) |
 
-|                      |                                                                      |
-| -------------------- | -------------------------------------------------------------------- |
-| **Backbone**         | ViT-B                                                                |
-| **Pre-training**     | `DINOv2`                                                             |
-| **Training data**    | **164,000,000** CT and **64,000,000** MRI DICOM images               |
-| **Downstream tasks** | General-purpose multimodal radiology representation learning         |
-| **Modalities**       | `CT`, `MRI`                                                          |
-| **Code**             | [github.com/raidium-med/curia](https://github.com/raidium-med/curia) |
+</details>
 
-
-
-
-
-
-**Percival** — A pan-organ vision–language model for generalizable 3D CT representations *(medRxiv 2025-07)*
+<a id="model-percival-202507"></a>
+<details>
+<summary><b>Percival</b> — A pan-organ vision–language model for generalizable 3D CT representations <i>(medRxiv 2025-07)</i></summary>
 
 **[A pan-organ vision–language model for generalizable 3D CT representations](https://pmc.ncbi.nlm.nih.gov/articles/PMC12236870/)**
 
-*medRxiv* · 2025-07 · Preprint
+*medRxiv* · 2025-07
 
+| | |
+| --- | --- |
+| **Backbone** | 3D DeiT |
+| **Pre-training** | `InfoNCE`, `contrastive`<br>Vision-language pretraining with CT volumes and reports. |
+| **Training data** | More than<br>**403,000** CT volumes |
+| **Downstream tasks** | `retrieval`, `classification`, `prognosis`<br>Pan-organ CT representation learning. |
+| **Modalities** | `CT`, `text` |
+| **Code** | [github.com/cams2b/percival](https://github.com/cams2b/percival) |
 
-|                      |                                                                                   |
-| -------------------- | --------------------------------------------------------------------------------- |
-| **Backbone**         | 3D DeiT                                                                           |
-| **Pre-training**     | `InfoNCE`, `contrastive` Vision-language pretraining with CT volumes and reports. |
-| **Training data**    | More than **403,000** CT volumes                                                  |
-| **Downstream tasks** | `retrieval`, `classification`, `prognosis` Pan-organ CT representation learning.  |
-| **Modalities**       | `CT`, `text`                                                                      |
-| **Code**             | [github.com/cams2b/percival](https://github.com/cams2b/percival)                  |
+</details>
 
-
-
-
-
-
-**Spark3D** — Revisiting MAE pre-training for 3D medical image segmentation *(CVPR 2025 2025-04)*
+<a id="model-spark3d-202504"></a>
+<details>
+<summary><b>Spark3D</b> — Revisiting MAE pre-training for 3D medical image segmentation <i>(CVPR 2025 2025-04)</i></summary>
 
 **[Revisiting MAE pre-training for 3D medical image segmentation](https://doi.org/10.1109/CVPR52734.2025.00489)**
 
-*CVPR 2025* · 2025-04 · Published · [doi:10.1109/CVPR52734.2025.00489](https://doi.org/10.1109/CVPR52734.2025.00489)
+*CVPR 2025* · 2025-04 · [doi:10.1109/CVPR52734.2025.00489](https://doi.org/10.1109/CVPR52734.2025.00489)
 
+| | |
+| --- | --- |
+| **Backbone** | CNN U-Net |
+| **Pre-training** | `MAE` |
+| **Training data** | **44,000** MRI volumes from **9,000** patients |
+| **Downstream tasks** | `segmentation`<br>Masked-autoencoder pretraining for three-dimensional medical segmentation. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/MIC-DKFZ/nnssl](https://github.com/MIC-DKFZ/nnssl) |
 
-|                      |                                                                                           |
-| -------------------- | ----------------------------------------------------------------------------------------- |
-| **Backbone**         | CNN U-Net                                                                                 |
-| **Pre-training**     | `MAE`                                                                                     |
-| **Training data**    | **44,000** MRI volumes from **9,000** patients                                            |
-| **Downstream tasks** | `segmentation` Masked-autoencoder pretraining for three-dimensional medical segmentation. |
-| **Modalities**       | `MRI`                                                                                     |
-| **Code**             | [github.com/MIC-DKFZ/nnssl](https://github.com/MIC-DKFZ/nnssl)                            |
+</details>
 
-
-
-
-
-
-
-
-**CT-FM** — Vision foundation models for computed tomography *(arXiv 2025-01)*
+<a id="model-ct-fm-202501"></a>
+<details>
+<summary><b>CT-FM</b> — Vision foundation models for computed tomography <i>(arXiv 2025-01)</i></summary>
 
 **[Vision foundation models for computed tomography](https://arxiv.org/abs/2501.09001)**
 
-*arXiv* · 2025-01 · Preprint · [arXiv:2501.09001](https://arxiv.org/abs/2501.09001)
+*arXiv* · 2025-01 · [arXiv:2501.09001](https://arxiv.org/abs/2501.09001)
 
+| | |
+| --- | --- |
+| **Backbone** | SegResEncoder |
+| **Pre-training** | `SimCLR` |
+| **Training data** | IDC corpus<br>**148,000** CT volumes |
+| **Downstream tasks** | `segmentation`, `triage`, `retrieval`<br>General-purpose computed-tomography representations. |
+| **Modalities** | `CT` |
+| **Code** | [github.com/project-lighter/CT-FM](https://github.com/project-lighter/CT-FM) |
+| **Weights** | [huggingface.co/project-lighter/ct_fm_feature_extractor](https://huggingface.co/project-lighter/ct_fm_feature_extractor) |
+| **PDF name** | `CT-FM - Vision Foundation Models for Computed Tomography.pdf` |
 
-|                      |                                                                                                                          |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| **Backbone**         | SegResEncoder                                                                                                            |
-| **Pre-training**     | `SimCLR`                                                                                                                 |
-| **Training data**    | IDC corpus **148,000** CT volumes                                                                                        |
-| **Downstream tasks** | `segmentation`, `triage`, `retrieval` General-purpose computed-tomography representations.                               |
-| **Modalities**       | `CT`                                                                                                                     |
-| **Code**             | [github.com/project-lighter/CT-FM](https://github.com/project-lighter/CT-FM)                                             |
-| **Weights**          | [huggingface.co/project-lighter/ct_fm_feature_extractor](https://huggingface.co/project-lighter/ct_fm_feature_extractor) |
-| **PDF name**         | `CT-FM - Vision Foundation Models for Computed Tomography.pdf`                                                           |
+</details>
 
-
-
-
-
-
-**3DINO** — A generalizable 3D framework and model for self-supervised learning in medical imaging *(arXiv 2025-01)*
+<a id="model-3dino-202501"></a>
+<details>
+<summary><b>3DINO</b> — A generalizable 3D framework and model for self-supervised learning in medical imaging <i>(arXiv 2025-01)</i></summary>
 
 **[A generalizable 3D framework and model for self-supervised learning in medical imaging](https://arxiv.org/abs/2501.11755)**
 
-*arXiv* · 2025-01 · Preprint · [arXiv:2501.11755](https://arxiv.org/abs/2501.11755)
+*arXiv* · 2025-01 · [arXiv:2501.11755](https://arxiv.org/abs/2501.11755)
 
+| | |
+| --- | --- |
+| **Backbone** | Vision transformer |
+| **Pre-training** | `3DINO`, `self-supervised` |
+| **Training data** | **1,300** patients |
+| **Downstream tasks** | `classification`, `segmentation`<br>Generalizable three-dimensional self-supervised medical imaging. |
+| **Modalities** | `CT`, `MRI` |
+| **Code** | [github.com/AICONSlab/3DINO](https://github.com/AICONSlab/3DINO) |
 
-|                      |                                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------------------- |
-| **Backbone**         | Vision transformer                                                                                |
-| **Pre-training**     | `3DINO`, `self-supervised`                                                                        |
-| **Training data**    | **1,300** patients                                                                                |
-| **Downstream tasks** | `classification`, `segmentation` Generalizable three-dimensional self-supervised medical imaging. |
-| **Modalities**       | `CT`, `MRI`                                                                                       |
-| **Code**             | [github.com/AICONSlab/3DINO](https://github.com/AICONSlab/3DINO)                                  |
+</details>
 
-
-
-
-
-
-**BME-X** — A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks *(Nat. Biomed. Eng. 2024-12)*
+<a id="model-bme-x-202412"></a>
+<details>
+<summary><b>BME-X</b> — A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks <i>(Nat. Biomed. Eng. 2024-12)</i></summary>
 
 **[A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks](https://www.nature.com/articles/s41551-024-01283-7)**
 
-*Nat. Biomed. Eng.* · 2024-12 · Published · [doi:10.1038/s41551-024-01283-7](https://doi.org/10.1038/s41551-024-01283-7)
+*Nat. Biomed. Eng.* · 2024-12 · [doi:10.1038/s41551-024-01283-7](https://doi.org/10.1038/s41551-024-01283-7)
 
+| | |
+| --- | --- |
+| **Backbone** | U-Net CNN |
+| **Pre-training** | Not recorded |
+| **Training data** | Numeric scale not recorded |
+| **Downstream tasks** | `segmentation`, `registration`, `classification`<br>MRI enhancement and downstream image-analysis tasks. |
+| **Modalities** | `MRI` |
+| **Code** | [github.com/DBC-Lab/Brain_MRI_Enhancement](https://github.com/DBC-Lab/Brain_MRI_Enhancement) |
 
-|                      |                                                                                                       |
-| -------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Backbone**         | U-Net CNN                                                                                             |
-| **Pre-training**     | Not recorded                                                                                          |
-| **Training data**    | Numeric scale not recorded                                                                            |
-| **Downstream tasks** | `segmentation`, `registration`, `classification` MRI enhancement and downstream image-analysis tasks. |
-| **Modalities**       | `MRI`                                                                                                 |
-| **Code**             | [github.com/DBC-Lab/Brain_MRI_Enhancement](https://github.com/DBC-Lab/Brain_MRI_Enhancement)          |
-
-
+</details>

--- a/radiology.md
+++ b/radiology.md
@@ -1,36 +1,709 @@
-**Maintainer:** @Judy Lyu
-
 # Radiology
 
-CT, MRI, PET, X-ray and fMRI.
+CT, MRI, PET, X-ray and fMRI foundation models.
 
-| Date | Title | First & Last Authors | Model | Network Backbone | Pre-training Method | Training Data | Downstream Tasks |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| 202607 | [Health system learning enables generalist neuroimaging models](https://www.nature.com/articles/s41591-026-04497-1) (Nat. Med.) | [Akhil Kondepudi](https://scholar.google.com/citations?user=TabSRQ8AAAAJ&hl=en) & [Todd Hollon](https://scholar.google.com/citations?user=37OCG3gAAAAJ&hl=en) | [NeuroVFM](https://github.com/MLNeurosurg/neurovfm) | 3D ViT | Vol-JEPA: self-supervised masked 3D latent prediction with EMA teacher–student learning. | 5.24 million clinical brain/head/neck CT and MRI volumes from Michigan Medicine. | Multi-disease diagnosis/classification, Radiology report generation, Clinical-acuity triage , Anatomical landmark matching , Pathology/tumor retrieval, Cross-modal CT→MRI diagnostic transfer, Brain-age estimation, Neurodegenerative, neurodevelopmental, and brain-injury prediction tasks |
-| 202607 | [Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications](https://www.nature.com/articles/s41551-026-01740-5) (Nat. Biomed. Eng.) | [Zeilin Qiu](https://orcid.org/0009-0002-8628-5061) & [Hao Chen](https://orcid.org/0000-0002-8400-3780) | [MARS](https://github.com/zqiuak/MARS) | 3D Swin Transformer | masked reconstruction, cross-sequence translation, anatomy-invariant contrastive learning, and metadata/body-region prediction. | 336,476 MRI volumes; 34 datasets (8 public, 26 private); 10 anatomical regions; multiple MRI sequences. | 44 tasks—diagnosis/classification, segmentation, registration, progression prediction, age estimation, and report generation. |
-| 202605 | [Predicting categorical and continuous Alzheimer's disease outcomes from a single MRI scan](https://doi.org/10.1038/s43587-026-01121-2) (Nat. Aging) | [Daren Ma](https://scholar.google.com/citations?user=N1TIix0AAAAJ) & [Ashish Raj](https://scholar.google.com/citations?user=ucYJhwEAAAAJ) | [MultitaskCognition (UNet+XGB Ensemble)](https://github.com/darenma/MultitaskCognition) | 3D UNet (custom), 3DResNet50 (MedicalNet/Tencent), XGBoost | UNet: supervised segmentation pretraining (HCP-YA + ADNI); MedicalNet: transfer learning from pretrained 3DResNet50 (multi-organ medical imaging) | ADNI (n=1,950), HCP-YA (n=1,008); out-of-sample test: DLBS (n=331) | AD diagnosis (binary), brain tissue segmentation (GM/WM/CSF), baseline ADAS-Cog11 prediction, longitudinal cognitive score prediction (up to 36 months) |
-| 202604 | [3D foundation model for generalizable disease detection in head computed tomography](https://www.nature.com/articles/s41551-026-01668-w) (Nat. Biomed. Eng.) | [Weicheng Zhu](https://scholar.google.com/citations?hl=zh-CN&user=Glw83HYAAAAJ&view_op=list_works) & [Narges Razavian](https://scholar.google.com/citations?user=lr1JM5MAAAAJ&hl=en) | [FM-HCT](https://github.com/NYUMedML/headCT_foundation?tab=readme-ov-file) | ViT | Self-supervised learning using the DINO (self-distillation) framework | 361,663 non-contrast 3D head CT scans from a major clinical institution (NYU Langone) | Disease detection and volume-to-volume retrival |
-| 202604 | [Towards a general-purpose foundation model for functional MRI analysis](https://www.nature.com/articles/s41551-026-01666-y) (Nat. Biomed. Eng.) | [Cheng Wang](https://scholar.google.com/citations?user=AM7gvyUAAAAJ) & [Hongbin Han](https://orcid.org/0000-0002-6988-4698), [Xiang Li](https://orcid.org/0000-0002-9851-6376), [Yixuan Yuan](https://orcid.org/0000-0002-0853-6948) | [NeuroFM](https://github.com/CUHK-AIM-Group/NeuroSTORM) | Shifted Window Mamba (SWM) Backbone | MAE with spatiotemporal redundancy dropout (STRD) module, task-specific prompt tuning (TPT) | 8.65 million fMRI frames from over 50,000 participants from UKB, ABCD, and HCP | Age Regression, Sex Classificaiton, Phenotype Prediciton, Disease Diagnosis |
-| 202603 | [A foundation model of vision, audition, and language for in-silico neuroscience](https://ai.meta.com/research/publications/a-foundation-model-of-vision-audition-and-language-for-in-silico-neuroscience/) (arXiv) | [Stéphane d'Ascoli](https://scholar.google.com/citations?user=2GcqQgYAAAAJ&hl=en) & [Jean-Rémi King](https://scholar.google.com/citations?user=XZOgIwEAAAAJ&hl=en) | [TRIBEv2](https://github.com/facebookresearch/tribev2) | V-JEPA2 (video), W2vec-Bert (audio), Llama3.2 (text), Transformer (fusion) | N/A | Courtois NeuroMod (movies/TV), BoldMoments (short video clips), Lebel2023 (podcast listening), and Wen2017 (silent videos) | Dense prediction (voxel-wise regression) |
-| 202603 | [Merlin: a computed tomography vision–language foundation model and dataset](https://www.nature.com/articles/s41586-026-10181-8) (Nature) | [Louis Blankemeier](https://scholar.google.com/citations?hl=zh-CN&user=z4SZH7MAAAAJ) & [Akshay S. Chaudhari](https://scholar.google.ca/citations?hl=en&user=RfuagnUAAAAJ) | [Merlin](https://github.com/StanfordMIMI/Merlin) | 3D (I3D) ResNet152 | Diagnostic Code Supervision CLIP | 25,528 CTs | classification, segmentation |
-| 202603 | [Thymic health and immunotherapy outcomes in patients with cancer](https://www.nature.com/articles/s41586-026-10243-x) (Nature) | [Simon Bernatz](https://scholar.google.com/citations?hl=en&user=pT13LyYAAAAJ&view_op=list_works) & [Hugo J. W. L. Aerts](https://scholar.google.com/citations?hl=en&user=v7G4QvIAAAAJ&view_op=list_works) | N/A | U-Net and 3D ResNet-50 | SwAV (Swapping Assignments between Views) | 5,674 thoracic CT scans | Binary classification task to distinguish between a fully fatty thymus and one with preserved soft tissue |
-| 202603 | [Thymic health consequences in adults](https://www.nature.com/articles/s41586-026-10242-y) (Nature) | [Simon Bernatz](https://scholar.google.com/citations?hl=en&user=pT13LyYAAAAJ&view_op=list_works) & [Hugo J. W. L. Aerts](https://scholar.google.com/citations?hl=en&user=v7G4QvIAAAAJ&view_op=list_works) | N/A | U-Net and 3D ResNet-50 | SwAV (Swapping Assignments between Views) | 5,674 thoracic CT scans | Binary classification task to distinguish between a fully fatty thymus and one with preserved soft tissue |
-| 202603 | [UPDATED- Merlin: a computed tomography vision–language foundation model and dataset](https://www.nature.com/articles/s41586-026-10181-8) (Nature) | [Louis Blankemeier](https://scholar.google.com/citations?user=z4SZH7MAAAAJ&hl=en) & [Akshay S. Chaudhari](https://scholar.google.com/citations?user=08Y4NhMAAAAJ&hl=en) | [Merlin](https://github.com/StanfordMIMI/Merlin) | 3D CT VLM with a ResNet + Longformer | CLIP (Contrastive Language-Image Pretraining) | Merlin Abdominal CT Dataset | classification of findings, Phenotype classification, cross-modal retrieval, Multi-disease 5-year prediction, Radiology report generation, 3D semantic segmentation |
-| 202602 | [A foundation model for breast and lung cancer screening using non-contrast computed tomography](https://doi.org/10.1038/s44360-026-00055-8) (Nat. Health) | [Zhiying Liang](https://scholar.google.ca/citations?hl=zh-TW&user=cTxJZ1kAAAAJ) & [Xuejun Qian](https://scholar.google.ca/citations?hl=zh-TW&user=puRYJ60AAAAJ) | [OMAFound](https://github.com/Qian-IMMULab/OMAFound) | N/A | N/A | N/A | N/A |
-| 202602 | [A generalizable deep learning system for cardiac MRI](https://www.nature.com/articles/s41551-026-01637-3) (Nat. Biomed. Eng.) | [Rohan Shad](https://scholar.google.com/citations?user=1gBss2IAAAAJ) & William Hiesinger | [CMR Transformer (cmr_c0.1)](https://github.com/rohanshad/cmr_transformer) | Multiscale Vision Transformer (mViT) + BERT (biomedical PubMed) | Self-supervised contrastive learning (text-supervised InfoNCE, cardiac MRI cine videos paired with radiology reports) | Stanford Medicine, UCSF, MedStar (19,041 scans via Bunkerhill Health); U Penn (2,033 scans); external: UK BioBank, ACDC, Kaggle MRI | LVEF regression; classification of 39 cardiovascular conditions (HCM, cardiac amyloidosis, ARVC, myocarditis, valvular disease, cardiac transplant rejection) |
-| 202602 | [A generalizable foundation model for analysis of human brain MRI](https://www.nature.com/articles/s41593-026-02202-6) (Nat. Neurosci.) | [Divyanshu tak](https://scholar.google.com/citations?user=QJKJ5p4AAAAJ&hl=en) & [Benjamin H Kann](https://scholar.google.com/citations?user=n_8rIysAAAAJ&hl=en) | [BrainIAC](https://github.com/AIM-KannLab/BrainIAC) | ViTb | SimCLR | Multiple different MRI databases total of 32,015 | MRI sequence classification, Brain age prediction, IDH mutation classification, Overall survival prediction, Mild Cognitive Impairment (MCI) classification, Time-to-stroke prediction, Tumor segmentation: |
-| 202602 | [Generalist foundation models from a multimodal dataset for 3D computed tomography](https://www.nature.com/articles/s41551-025-01599-y) (Nat. Biomed. Eng.) | [Ibrahim Ethem Hamamci](https://scholar.google.com/citations?user=7bN36N0AAAAJ) & [Bjoern Menze](https://scholar.google.com/citations?user=Kv2QrQgAAAAJ) | [CT-CLIP; CT-CHAT](https://github.com/ibrahimethemhamamci/CT-CLIP) | CT-ViT (Vision Transformer for 3D CT) | Contrastive Learning (CLIP) | 25692 | Multi-abnormality detection; case retrieval; VQA |
-| 202602 | [Learning neuroimaging models from health system-scale data](https://www.nature.com/articles/s41551-025-01608-0) (Nat. Biomed. Eng.) | [Yiwei Lyu](https://scholar.google.com/citations?user=fV5fYpsAAAAJ&hl=en) & [Todd Hollon](https://scholar.google.com/citations?user=37OCG3gAAAAJ&hl=en) | PRIMA | Hiearchical ViT | CLIP (Contrastive Language-Image Pretraining) | UM-220K221,147 MRI studies from over 170,000 diverse patients. In total, this encompasses more than 5.6 million 3D MRI sequences, 362 million 2D MRI slices | 52 distinct radiologic diagnoses, prioritizing radiologist worklists, recommending specialty clinical referrals, and performing out-of-domain evaluations like brain age estimation and dementia classification |
-| 202602 | [Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease](https://www.nature.com/articles/s41467-026-68414-3) (Nat. Commun.) | [Yuan Gao](https://scholar.google.com/citations?user=1Tvfo7wAAAAJ&hl=en&oi=sra) & [Yu Shi](https://scholar.google.co.uk/citations?hl=en&user=C9RebY0AAAAJ&view_op=list_works&sortby=pubdate) | [MAOSS](https://github.com/YGOX/MAOSS) | 3D ResNet-34 for image encoder, ViLT for multimodal fusion | N/A | private: SHCMU, NDTH, FAHZU, SIPD / public: UNIFESP(n=226) | hepatic steatosis grading, liver fibrosis grading (ordinal regression) |
-| 202601 | [A multimodal vision–language model for generalizable annotation-free pathology localization](https://www.nature.com/articles/s41551-025-01574-7) (Nat. Biomed. Eng.) | [Hao Yang](https://scholar.google.com/citations?user=cZX7mo8AAAAJ&hl=zh-CN) & [Shanshan Wang](https://scholar.google.com/citations?user=8pnz5L4AAAAJ&hl=en) | [AFLoc](https://github.com/YH0517/AFLoc) | Resnet(image) + BioClinicalBERT (report) | CLIP-like (Contrastive Language-Image Pretraining) | MIMIC-CXR | pathology localization, diagnosis/classification |
-| 202601 | [deepmriprep: voxel-based morphometry preprocessing via deep neural networks](https://www.nature.com/articles/s43588-026-00953-7) (Nat. Comput. Sci.) | Lukas Fisch & [Tim Hahn](https://scholar.google.ca/citations?user=Zj8hyTAAAAAJ&hl=en&oi=ao) | [deepmriprep](https://github.com/wwu-mmll/deepmriprep-train) | 3D U-Net | N/A | OpenNeuro-HD; 685 high-resolution adult T1-weighted MRIs | Voxel-Based Morphometry (VBM) Analysis |
-| 202601 | [From 100,000+ images to winning the first brain MRI foundation model challenges: Sharing lessons and models](https://arxiv.org/abs/2601.13166) (arXiv) | [Pedro M. Gordaliza](https://scholar.google.com/citations?user=QZQzIKIAAAAJ&hl=en) & [Meritxell Bach Cuadra](https://scholar.google.com/citations?user=UoZ4neoAAAAJ&hl=fr) | [FOMO25](https://github.com/jbanusco/BrainFM4Challenges) | CNN U-Net | MAE | SSL3D Challenge Data: 114,570 3D MRI volumes from 34,191 subjects, FOMO25 Challenge Data:60,529 3D MRI 11,187 subjects | SSL3D: Segmentation: Multiple Sclerosis (MS) lesions, Glioblastoma, Pediatric Glioblastoma, and Brain Metastases.Classification: Glioblastoma versus Lymphoma, Tumor versus Necrosis, and Stroke mismatch. FOMO: Segmentation: Meningioma segmentation.Classification: Stroke detection.Regression: Brain age estimation |
-| 202512 | [Revisiting 2D Foundation Models for Scalable 3D Medical Image Classification](https://arxiv.org/pdf/2512.12887) (arXiv) | [Han Liu](https://scholar.google.ca/citations?user=38YPqAkAAAAJ&hl=en&oi=sra) & [Sasa Grbic](https://scholar.google.ca/citations?user=VCbqAkcAAAAJ&hl=en&oi=sra) | AnyMC3D | DINOv2, DINOv3 | The authors utilize DINOv2 and DINOv3, which were pretrained on massive datasets of natural images using self-supervised learning | The authors established a comprehensive benchmark of 12 diverse 3D classification tasks (T1–T12) to evaluate their method across various anatomies, pathologies, and modalities | 12 different classifications tasks |
-| 202511 | [Scaling Self-Supervised and Cross-Modal Pretraining for Volumetric CT Transformers](https://arxiv.org/abs/2511.17209) (CVPR 2026) | [Cris Claessens](https://scholar.google.com/citations?user=48laGBwAAAAJ&hl=en) & [Fons van der Sommen](https://scholar.google.com/citations?user=qFiLkCAAAAAJ&hl=en) | [SPECTRE](https://github.com/cclaess/SPECTRE) | 3D Vision Transformer (Local ViTl + Global ViTg) | DINOv3 (SSL) + SigLIP (VLA) | NLST, CT-RATE, INSPECT, Merlin, AbdomenAtlas, AMOS, PANORAMA, AbdomenCT-1K (229,619 CT scans) | Cancer biomarker classification, Semantic segmentation, Zero-shot text-to-image retrieval |
-| 202510 | [Towards Generalisable Foundation Models for Brain MRI](https://arxiv.org/abs/2510.23415) (arXiv) | [Moona Mazher](https://scholar.google.com/citations?user=TDPgF4IAAAAJ&hl=en) & [Daniel Alexander](https://scholar.google.com/citations?user=mH-ZOQEAAAAJ&hl=en) | [BrainFound](https://github.com/Moona-Mazher/BrainFound) | ViT-Large | DINOv2 | 10,000 unlabeled volumetric brain MRI scans across T1, T2, and FLAIR modalities, curated from 12 public datasets | neurodegenerative disease detection (Alzheimer’s, mild cognitive impairment, Lewy body dementia, and frontotemporal dementia) and oncological brain tumour grading |
-| 202509 | [An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer](https://www.nature.com/articles/s43018-025-01041-x) (Nat. Cancer) | [Lizhi Shao](https://scholar.google.com/citations?user=iCdx1zIAAAAJ&hl=en&oi=sra) & Shancheng Ren | [MRI-PTPCa](https://github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer) | CNN, ViT | Contrastive Learning (BYOL) | N/A | N/A |
-| 202508 | [Curia: A Multi-Modal Foundation Model for Radiology](https://arxiv.org/pdf/2509.06830) (arXiv) | [Corentin Dancette](https://scholar.google.com/citations?user=2zReQdQAAAAJ&hl=en) & [Paul Herent](https://scholar.google.com/citations?user=ZS9f4Q0AAAAJ&hl=fr) | [Curia](https://github.com/raidium-med/curia) | ViTb | DINOv2 | Private Hospital data (164 million CT DICOM files and 64 million MRI DICOM files) | N/A |
-| 202507 | [A Pan-Organ Vision-Language Model for Generalizable 3D CT Representations](https://pmc.ncbi.nlm.nih.gov/articles/PMC12236870/) (medRxiv) | [Cameron Beeche](https://scholar.google.com/citations?user=Pi-9PuwAAAAJ) & [Walter R. Witschey](https://scholar.google.com/citations?user=_bh0tisAAAAJ) | [Percival](https://github.com/cams2b/percival) | DeiT (Data-Efficient Image Transformer, 3D) | Contrastive Learning (InfoNCE) | 402958 | Image-text retrieval; disease classification; prognostic risk modeling |
-| 202504 | [Revisiting MAE pre-training for 3D medical image segmentation](https://doi.org/10.1109/CVPR52734.2025.00489) (CVPR 2025) | [Tassilo Wald](https://scholar.google.com/citations?user=alSWmJcAAAAJ&hl=de) & [Klaus Maier-Hein](https://scholar.google.com/citations?user=oCrBpVMAAAAJ&hl=en) | [Spark3D](https://github.com/MIC-DKFZ/nnssl) | U-Net-style CNN | MAE | 44,000 3D MRI scans, 9000 patients | Segmentation |
-| 202501 | [A generalizable 3D framework and model for self-supervised learning in medical imaging](https://arxiv.org/pdf/2501.11755) (Preprint) | [Tony Xu](https://scholar.google.com/citations?user=3vwB4oEAAAAJ&hl=zh-CN&oi=sra) & [Maged Goubran](https://scholar.google.ca/citations?hl=en&user=O39vxT0AAAAJ) | [3DINO](https://github.com/AICONSlab/3DINO) | ViT | 3DINO | 1251patients | classification, segmentation |
-| 202412 | [A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks](https://www.nature.com/articles/s41551-024-01283-7) (Nat. Biomed. Eng.) | [Yue Sun](https://scholar.google.ca/citations?user=QMa2E4gAAAAJ&hl=en&oi=sra) & [Li Wang](https://scholar.google.ca/citations?user=xjzMf0cAAAAJ&hl=en&oi=sra) | [BME-X](https://github.com/DBC-Lab/Brain_MRI_Enhancement) | U-Net-style CNN | N/A | N/A | Segmentation, parcellation, registration, diagnosis |
+**Maintainer:** [Judy Lyu](https://github.com/judylyu)
+
+**31 papers** · **Last updated: 2026-08** · [Back to index](README.md)
+
+## Paper overview
+
+Click a model name to jump to its expandable record. A dash (`—`) means that the corresponding value has not been confirmed from the paper or an official release.
+
+
+| Date    | Model                                                  | Venue             | Modality                  | Training data                     | Training / adaptation              | Downstream tasks                                                         |
+| ------- | ------------------------------------------------------ | ----------------- | ------------------------- | --------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| 2026-07 | [NeuroVFM](#model-neurovfm-202607)                     | Nat. Med.         | CT, MRI                   | 5.24M volumes                     | JEPA                               | classification, report generation, retrieval, triage, registration       |
+| 2026-07 | [MARS](#model-mars-202607)                             | Nat. Biomed. Eng. | MRI                       | 336K volumes                      | MAE, contrastive learning          | classification, segmentation, registration, report generation, prognosis |
+| 2026-05 | [MultitaskCognition](#model-multitaskcognition-202605) | Nat. Aging        | MRI                       | ~3K studies                       | supervised, transfer learning      | classification, segmentation, regression, prognosis                      |
+| 2026-04 | [FM-HCT](#model-fm-hct-202604)                         | Nat. Biomed. Eng. | CT                        | 362K volumes                      | DINO                               | classification, retrieval                                                |
+| 2026-04 | [NeuroFM](#model-neurofm-202604)                       | Nat. Biomed. Eng. | fMRI                      | 8.65M frames                      | MAE                                | regression, classification, prognosis                                    |
+| 2026-03 | [TRIBEv2](#model-tribev2-202603)                       | arXiv             | fMRI, vision, audio, text | Multiple datasets                 | Multimodal representation learning | regression                                                               |
+| 2026-03 | [Merlin](#model-merlin-202603)                         | Nature            | CT, text                  | 25.5K CT volumes                  | CLIP                               | classification, segmentation, retrieval, report generation, prognosis    |
+| 2026-03 | [Thymus-IO](#model-thymus-io-202603)                   | Nature            | CT                        | 5.7K CT volumes                   | SwAV                               | classification, prognosis                                                |
+| 2026-03 | [Thymus-Adult](#model-thymus-adult-202603)             | Nature            | CT                        | 5.7K CT volumes                   | SwAV                               | classification                                                           |
+| 2026-02 | [OMAFound](#model-omafound-202602)                     | Nat. Health       | CT                        | 325.2K CT volumes                 | self-supervised                    | classification                                                           |
+| 2026-02 | [CMR Transformer](#model-cmr-transformer-202602)       | Nat. Biomed. Eng. | MRI, text                 | ~21K scans                        | InfoNCE, contrastive               | regression, classification                                               |
+| 2026-02 | [BrainIAC](#model-brainiac-202602)                     | Nat. Neurosci.    | MRI                       | 32K scans                         | SimCLR                             | classification, regression, segmentation, prognosis                      |
+| 2026-02 | [CT-CLIP / CT-CHAT](#model-ct-clip-ct-chat-202602)     | Nat. Biomed. Eng. | CT, text                  | 25.7K CT volumes                  | CLIP                               | classification, retrieval, VQA                                           |
+| 2026-02 | [PRIMA](#model-prima-202602)                           | Nat. Biomed. Eng. | MRI, text                 | 221K studies                      | CLIP                               | classification, triage, regression                                       |
+| 2026-02 | [MAOSS](#model-maoss-202602)                           | Nat. Commun.      | CT, text                  | Multisite data + 226 publications | —                                  | classification, prognosis                                                |
+| 2026-01 | [AFLoc](#model-afloc-202601)                           | Nat. Biomed. Eng. | X-ray, text               | MIMIC-CXR                         | CLIP                               | localization, classification                                             |
+| 2026-01 | [deepmriprep](#model-deepmriprep-202601)               | Nat. Comput. Sci. | MRI                       | 685 MRI scans                     | —                                  | preprocessing                                                            |
+| 2026-01 | [FOMO25](#model-fomo25-202601)                         | arXiv             | MRI                       | 176K volumes                      | MAE                                | segmentation, classification, regression                                 |
+| 2025-12 | [VoCo](#model-voco-202512)                             | IEEE TPAMI        | CT                        | 160K volumes                      | VoCo, contrastive learning         | segmentation, classification, regression, vision-language modeling       |
+| 2025-12 | [TAP-CT](#model-tap-ct-202512)                         | arXiv             | CT                        | 105K volumes                      | DINOv2                             | segmentation, classification                                             |
+| 2025-12 | [AnyMC3D](#model-anymc3d-202512)                       | arXiv             | CT, MRI                   | —                                 | DINOv2, DINOv3                     | classification                                                           |
+| 2025-11 | [Pillar-0](#model-pillar-0-202511)                     | arXiv             | CT, MRI, text             | ~155K volumes                     | contrastive, vision-language       | classification, prognosis                                                |
+| 2025-11 | [SPECTRE](#model-spectre-202511)                       | CVPR 2026         | CT, text                  | 230K CT volumes                   | DINOv3, SigLIP                     | classification, segmentation, retrieval                                  |
+| 2025-10 | [BrainFound](#model-brainfound-202510)                 | arXiv             | MRI                       | 10K volumes                       | DINOv2                             | classification                                                           |
+| 2025-09 | [MRI-PTPCa](#model-mri-ptpca-202509)                   | Nat. Cancer       | MRI, histopathology       | —                                 | BYOL                               | classification, grading                                                  |
+| 2025-08 | [Curia](#model-curia-202508)                           | arXiv             | CT, MRI                   | 228M DICOM images                 | DINOv2                             | General-purpose multimodal radiology representation learning             |
+| 2025-07 | [Percival](#model-percival-202507)                     | medRxiv           | CT, text                  | 403K CT volumes                   | InfoNCE, contrastive               | retrieval, classification, prognosis                                     |
+| 2025-04 | [Spark3D](#model-spark3d-202504)                       | CVPR 2025         | MRI                       | 44K MRI volumes                   | MAE                                | segmentation                                                             |
+| 2025-01 | [CT-FM](#model-ct-fm-202501)                           | arXiv             | CT                        | 148K CT volumes                   | SimCLR                             | segmentation, triage, retrieval                                          |
+| 2025-01 | [3DINO](#model-3dino-202501)                           | arXiv             | CT, MRI                   | 1.3K patients                     | 3DINO, self-supervised             | classification, segmentation                                             |
+| 2024-12 | [BME-X](#model-bme-x-202412)                           | Nat. Biomed. Eng. | MRI                       | —                                 | —                                  | segmentation, registration, classification                               |
+
+
+
+
+## Details
+
+Click a model to expand its record.
+
+
+
+**NeuroVFM** — Health system learning enables generalist neuroimaging models *(Nat. Med. 2026-07)*
+
+**[Health system learning enables generalist neuroimaging models](https://www.nature.com/articles/s41591-026-04497-1)**
+
+*Nat. Med.* · 2026-07 · Published · [doi:10.1038/s41591-026-04497-1](https://doi.org/10.1038/s41591-026-04497-1)
+
+
+|                      |                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Backbone**         | 3D vision transformer                                                                                               |
+| **Pre-training**     | `JEPA` Volumetric joint-embedding predictive pretraining.                                                           |
+| **Training data**    | CT and MRI neuroimaging **5,240,000** volumes                                                                       |
+| **Downstream tasks** | `classification`, `report generation`, `retrieval`, `triage`, `registration` Generalist health-system neuroimaging. |
+| **Modalities**       | `CT`, `MRI`                                                                                                         |
+| **Code**             | [github.com/MLNeurosurg/neurovfm](https://github.com/MLNeurosurg/neurovfm)                                          |
+
+
+
+
+
+
+**MARS** — Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications *(Nat. Biomed. Eng. 2026-07)*
+
+**[Large-scale multi-sequence pretraining for generalizable MRI analysis in versatile clinical applications](https://www.nature.com/articles/s41551-026-01740-5)**
+
+*Nat. Biomed. Eng.* · 2026-07 · Published · [doi:10.1038/s41551-026-01740-5](https://doi.org/10.1038/s41551-026-01740-5)
+
+
+|                      |                                                                                                                        |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| **Backbone**         | 3D Swin Transformer                                                                                                    |
+| **Pre-training**     | `MAE`, `contrastive learning`                                                                                          |
+| **Training data**    | Multi-sequence MRI **336,000** volumes                                                                                 |
+| **Downstream tasks** | `classification`, `segmentation`, `registration`, `report generation`, `prognosis` Evaluated across 44 clinical tasks. |
+| **Modalities**       | `MRI`                                                                                                                  |
+| **Code**             | [github.com/zqiuak/MARS](https://github.com/zqiuak/MARS)                                                               |
+
+
+
+
+
+
+**MultitaskCognition** — Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan *(Nat. Aging 2026-05)*
+
+**[Predicting categorical and continuous Alzheimer’s disease outcomes from a single MRI scan](https://doi.org/10.1038/s43587-026-01121-2)**
+
+*Nat. Aging* · 2026-05 · Published · [doi:10.1038/s43587-026-01121-2](https://doi.org/10.1038/s43587-026-01121-2)
+
+
+|                      |                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Backbone**         | 3D U-Net, ResNet-50 and XGBoost                                                                                  |
+| **Pre-training**     | `supervised`, `transfer learning`                                                                                |
+| **Training data**    | Approximately **3,000** MRI studies                                                                              |
+| **Downstream tasks** | `classification`, `segmentation`, `regression`, `prognosis` Alzheimer’s disease outcomes from a single MRI scan. |
+| **Modalities**       | `MRI`                                                                                                            |
+| **Code**             | [github.com/darenma/MultitaskCognition](https://github.com/darenma/MultitaskCognition)                           |
+
+
+
+
+
+
+**FM-HCT** — 3D foundation model for generalizable disease detection in head computed tomography *(Nat. Biomed. Eng. 2026-04)*
+
+**[3D foundation model for generalizable disease detection in head computed tomography](https://www.nature.com/articles/s41551-026-01668-w)**
+
+*Nat. Biomed. Eng.* · 2026-04 · Published · [doi:10.1038/s41551-026-01668-w](https://doi.org/10.1038/s41551-026-01668-w)
+
+
+|                      |                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| **Backbone**         | Vision transformer                                                                     |
+| **Pre-training**     | `DINO`                                                                                 |
+| **Training data**    | Head CT **362,000** volumes                                                            |
+| **Downstream tasks** | `classification`, `retrieval` Generalizable disease detection in head CT.              |
+| **Modalities**       | `CT`                                                                                   |
+| **Code**             | [github.com/NYUMedML/headCT_foundation](https://github.com/NYUMedML/headCT_foundation) |
+
+
+
+
+
+
+**NeuroFM** — Towards a general-purpose foundation model for functional MRI analysis *(Nat. Biomed. Eng. 2026-04)*
+
+**[Towards a general-purpose foundation model for functional MRI analysis](https://www.nature.com/articles/s41551-026-01666-y)**
+
+*Nat. Biomed. Eng.* · 2026-04 · Published · [doi:10.1038/s41551-026-01666-y](https://doi.org/10.1038/s41551-026-01666-y)
+
+
+|                      |                                                                                      |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| **Backbone**         | Spatiotemporal waveform Mamba                                                        |
+| **Pre-training**     | `MAE`                                                                                |
+| **Training data**    | More than **50,000** subjects and **8,650,000** fMRI frames                          |
+| **Downstream tasks** | `regression`, `classification`, `prognosis` General-purpose functional MRI analysis. |
+| **Modalities**       | `fMRI`                                                                               |
+| **Code**             | [github.com/CUHK-AIM-Group/NeuroSTORM](https://github.com/CUHK-AIM-Group/NeuroSTORM) |
+
+
+
+
+
+
+**TRIBEv2** — A foundation model of vision, audition, and language for in-silico neuroscience *(arXiv 2026-03)*
+
+**[A foundation model of vision, audition, and language for in-silico neuroscience](https://ai.meta.com/research/publications/a-foundation-model-of-vision-audition-and-language-for-in-silico-neuroscience/)**
+
+*arXiv* · 2026-03 · Preprint
+
+
+|                      |                                                                                    |
+| -------------------- | ---------------------------------------------------------------------------------- |
+| **Backbone**         | V-JEPA 2, wav2vec and Llama                                                        |
+| **Pre-training**     | Multimodal representation learning                                                 |
+| **Training data**    | Multiple datasets; numeric scale not recorded                                      |
+| **Downstream tasks** | `regression` Maps vision, audio and language stimuli to predicted brain voxels.    |
+| **Modalities**       | `fMRI`, `vision`, `audio`, `text`                                                  |
+| **Code**             | [github.com/facebookresearch/tribev2](https://github.com/facebookresearch/tribev2) |
+
+
+
+
+
+
+**Merlin** — Merlin: a computed tomography vision–language foundation model and dataset *(Nature 2026-03)*
+
+**[Merlin: a computed tomography vision–language foundation model and dataset](https://www.nature.com/articles/s41586-026-10181-8)**
+
+*Nature* · 2026-03 · Updated · [doi:10.1038/s41586-026-10181-8](https://doi.org/10.1038/s41586-026-10181-8)
+
+
+|                      |                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------- |
+| **Backbone**         | ResNet vision encoder and Longformer text encoder                               |
+| **Pre-training**     | `CLIP`                                                                          |
+| **Training data**    | CT volumes paired with clinical text **25,500** CT volumes                      |
+| **Downstream tasks** | `classification`, `segmentation`, `retrieval`, `report generation`, `prognosis` |
+| **Modalities**       | `CT`, `text`                                                                    |
+| **Code**             | [github.com/StanfordMIMI/Merlin](https://github.com/StanfordMIMI/Merlin)        |
+| **Dataset**          | [github.com/StanfordMIMI/Merlin](https://github.com/StanfordMIMI/Merlin)        |
+
+
+
+
+
+
+**Thymus-IO** — Thymic health and immunotherapy outcomes in patients with cancer *(Nature 2026-03)*
+
+**[Thymic health and immunotherapy outcomes in patients with cancer](https://www.nature.com/articles/s41586-026-10243-x)**
+
+*Nature* · 2026-03 · Published · [doi:10.1038/s41586-026-10243-x](https://doi.org/10.1038/s41586-026-10243-x)
+
+
+|                      |                                                                                     |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| **Backbone**         | U-Net and 3D ResNet-50                                                              |
+| **Pre-training**     | `SwAV`                                                                              |
+| **Training data**    | **5,700** CT volumes                                                                |
+| **Downstream tasks** | `classification`, `prognosis` Associates thymic health with immunotherapy outcomes. |
+| **Modalities**       | `CT`                                                                                |
+
+
+
+
+
+
+**Thymus-Adult** — Thymic health consequences in adults *(Nature 2026-03)*
+
+**[Thymic health consequences in adults](https://www.nature.com/articles/s41586-026-10242-y)**
+
+*Nature* · 2026-03 · Published · [doi:10.1038/s41586-026-10242-y](https://doi.org/10.1038/s41586-026-10242-y)
+
+
+|                      |                                                    |
+| -------------------- | -------------------------------------------------- |
+| **Backbone**         | U-Net and 3D ResNet-50                             |
+| **Pre-training**     | `SwAV`                                             |
+| **Training data**    | **5,700** CT volumes                               |
+| **Downstream tasks** | `classification` Assesses thymic health in adults. |
+| **Modalities**       | `CT`                                               |
+
+
+
+
+
+
+**OMAFound** — A foundation model for breast and lung cancer screening using non-contrast computed tomography *(Nat. Health 2026-02)*
+
+**[A foundation model for breast and lung cancer screening using non-contrast computed tomography](https://doi.org/10.1038/s44360-026-00055-8)**
+
+*Nat. Health* · 2026-02 · Published · [doi:10.1038/s44360-026-00055-8](https://doi.org/10.1038/s44360-026-00055-8)
+
+
+|                      |                                                                              |
+| -------------------- | ---------------------------------------------------------------------------- |
+| **Backbone**         | SwinUNETR-V2 encoder                                                         |
+| **Pre-training**     | `self-supervised` Rotation, reconstruction and contrastive objectives.       |
+| **Training data**    | Ten CT datasets **325,197** CT volumes · **151,386** patients                |
+| **Downstream tasks** | `classification` Breast and lung cancer screening from non-contrast CT.      |
+| **Modalities**       | `CT`                                                                         |
+| **Code**             | [github.com/Qian-IMMULab/OMAFound](https://github.com/Qian-IMMULab/OMAFound) |
+
+
+
+
+
+
+**CMR Transformer** — A generalizable deep learning system for cardiac MRI *(Nat. Biomed. Eng. 2026-02)*
+
+**[A generalizable deep learning system for cardiac MRI](https://www.nature.com/articles/s41551-026-01637-3)**
+
+*Nat. Biomed. Eng.* · 2026-02 · Published · [doi:10.1038/s41551-026-01637-3](https://doi.org/10.1038/s41551-026-01637-3)
+
+
+|                      |                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------- |
+| **Backbone**         | Multiscale vision transformer and BERT text encoder                                                 |
+| **Pre-training**     | `InfoNCE`, `contrastive` Image-report contrastive learning.                                         |
+| **Training data**    | Cardiac MRI with paired reports Approximately **21,000** scans                                      |
+| **Downstream tasks** | `regression`, `classification` Left-ventricular ejection fraction and 39 cardiovascular conditions. |
+| **Modalities**       | `MRI`, `text`                                                                                       |
+| **Code**             | [github.com/rohanshad/cmr_transformer](https://github.com/rohanshad/cmr_transformer)                |
+
+
+
+
+
+
+**BrainIAC** — A generalizable foundation model for analysis of human brain MRI *(Nat. Neurosci. 2026-02)*
+
+**[A generalizable foundation model for analysis of human brain MRI](https://www.nature.com/articles/s41593-026-02202-6)**
+
+*Nat. Neurosci.* · 2026-02 · Published · [doi:10.1038/s41593-026-02202-6](https://doi.org/10.1038/s41593-026-02202-6)
+
+
+|                      |                                                                                                  |
+| -------------------- | ------------------------------------------------------------------------------------------------ |
+| **Backbone**         | ViT-B                                                                                            |
+| **Pre-training**     | `SimCLR`                                                                                         |
+| **Training data**    | **32,000** MRI scans                                                                             |
+| **Downstream tasks** | `classification`, `regression`, `segmentation`, `prognosis` Generalizable analysis of brain MRI. |
+| **Modalities**       | `MRI`                                                                                            |
+| **Code**             | [github.com/AIM-KannLab/BrainIAC](https://github.com/AIM-KannLab/BrainIAC)                       |
+
+
+
+
+
+
+**CT-CLIP / CT-CHAT** — Generalist foundation models from a multimodal dataset for 3D computed tomography *(Nat. Biomed. Eng. 2026-02)*
+
+**[Generalist foundation models from a multimodal dataset for 3D computed tomography](https://www.nature.com/articles/s41551-025-01599-y)**
+
+*Nat. Biomed. Eng.* · 2026-02 · Published · [doi:10.1038/s41551-025-01599-y](https://doi.org/10.1038/s41551-025-01599-y)
+
+
+|                      |                                                                                              |
+| -------------------- | -------------------------------------------------------------------------------------------- |
+| **Backbone**         | CT-ViT                                                                                       |
+| **Pre-training**     | `CLIP` Contrastive alignment of CT volumes and radiology reports.                            |
+| **Training data**    | CT-RATE **25,692** CT volumes                                                                |
+| **Downstream tasks** | `classification`, `retrieval`, `VQA` Generalist 3D CT vision-language analysis and dialogue. |
+| **Modalities**       | `CT`, `text`                                                                                 |
+| **Code**             | [github.com/ibrahimethemhamamci/CT-CLIP](https://github.com/ibrahimethemhamamci/CT-CLIP)     |
+
+
+
+
+
+
+**PRIMA** — Learning neuroimaging models from health system-scale data *(Nat. Biomed. Eng. 2026-02)*
+
+**[Learning neuroimaging models from health system-scale data](https://www.nature.com/articles/s41551-025-01608-0)**
+
+*Nat. Biomed. Eng.* · 2026-02 · Published · [doi:10.1038/s41551-025-01608-0](https://doi.org/10.1038/s41551-025-01608-0)
+
+
+|                      |                                                                                 |
+| -------------------- | ------------------------------------------------------------------------------- |
+| **Backbone**         | Hierarchical vision transformer                                                 |
+| **Pre-training**     | `CLIP`                                                                          |
+| **Training data**    | **221,000** MRI studies · **5,600,000** sequences                               |
+| **Downstream tasks** | `classification`, `triage`, `regression` Prediction of 52 radiologic diagnoses. |
+| **Modalities**       | `MRI`, `text`                                                                   |
+
+
+
+
+
+
+**MAOSS** — Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease *(Nat. Commun. 2026-02)*
+
+**[Multi-modal AI for opportunistic screening, staging and progression risk stratification of steatotic liver disease](https://www.nature.com/articles/s41467-026-68414-3)**
+
+*Nat. Commun.* · 2026-02 · Published · [doi:10.1038/s41467-026-68414-3](https://doi.org/10.1038/s41467-026-68414-3)
+
+
+|                      |                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Backbone**         | 3D ResNet-34 and ViLT                                                                                            |
+| **Pre-training**     | Not recorded                                                                                                     |
+| **Training data**    | Multisite imaging data and information from 226 publications                                                     |
+| **Downstream tasks** | `classification`, `prognosis` Screening, staging and progression-risk stratification of steatotic liver disease. |
+| **Modalities**       | `CT`, `text`                                                                                                     |
+| **Code**             | [github.com/YGOX/MAOSS](https://github.com/YGOX/MAOSS)                                                           |
+
+
+
+
+
+
+**AFLoc** — A multimodal vision–language model for generalizable annotation-free pathology localization *(Nat. Biomed. Eng. 2026-01)*
+
+**[A multimodal vision–language model for generalizable annotation-free pathology localization](https://www.nature.com/articles/s41551-025-01574-7)**
+
+*Nat. Biomed. Eng.* · 2026-01 · Published · [doi:10.1038/s41551-025-01574-7](https://doi.org/10.1038/s41551-025-01574-7)
+
+
+|                      |                                                                             |
+| -------------------- | --------------------------------------------------------------------------- |
+| **Backbone**         | ResNet and BioClinicalBERT                                                  |
+| **Pre-training**     | `CLIP`                                                                      |
+| **Training data**    | MIMIC-CXR                                                                   |
+| **Downstream tasks** | `localization`, `classification` Annotation-free pathology localization.    |
+| **Modalities**       | `X-ray`, `text`                                                             |
+| **Code**             | [github.com/YH0517/AFLoc](https://github.com/YH0517/AFLoc)                  |
+| **Dataset**          | [physionet.org/content/mimic-cxr](https://physionet.org/content/mimic-cxr/) |
+
+
+
+
+
+
+**deepmriprep** — deepmriprep: voxel-based morphometry preprocessing via deep neural networks *(Nat. Comput. Sci. 2026-01)*
+
+**[deepmriprep: voxel-based morphometry preprocessing via deep neural networks](https://www.nature.com/articles/s43588-026-00953-7)**
+
+*Nat. Comput. Sci.* · 2026-01 · Published · [doi:10.1038/s43588-026-00953-7](https://doi.org/10.1038/s43588-026-00953-7)
+
+
+|                      |                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| **Backbone**         | 3D U-Net                                                                               |
+| **Pre-training**     | Not recorded                                                                           |
+| **Training data**    | **685** MRI scans                                                                      |
+| **Downstream tasks** | `preprocessing` Deep-learning voxel-based morphometry preprocessing.                   |
+| **Modalities**       | `MRI`                                                                                  |
+| **Code**             | [github.com/wwu-mmll/deepmriprep-train](https://github.com/wwu-mmll/deepmriprep-train) |
+
+
+
+
+
+
+**FOMO25** — From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models *(arXiv 2026-01)*
+
+**[From 100,000+ images to winning the first brain MRI foundation model challenges: sharing lessons and models](https://arxiv.org/abs/2601.13166)**
+
+*arXiv* · 2026-01 · Preprint · [arXiv:2601.13166](https://arxiv.org/abs/2601.13166)
+
+
+|                      |                                                                                          |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| **Backbone**         | CNN U-Net                                                                                |
+| **Pre-training**     | `MAE`                                                                                    |
+| **Training data**    | **115,000 + 61,000** MRI volumes                                                         |
+| **Downstream tasks** | `segmentation`, `classification`, `regression` SSL3D and FOMO25 challenge tasks.         |
+| **Modalities**       | `MRI`                                                                                    |
+| **Code**             | [github.com/jbanusco/BrainFM4Challenges](https://github.com/jbanusco/BrainFM4Challenges) |
+
+
+
+
+
+
+**VoCo** — Large-scale 3D medical image pre-training with geometric context priors *(IEEE TPAMI 2025-12)*
+
+**[Large-scale 3D medical image pre-training with geometric context priors](https://doi.org/10.1109/tpami.2025.3639593)**
+
+*IEEE TPAMI* · 2025-12 · Published · [doi:10.1109/TPAMI.2025.3639593](https://doi.org/10.1109/tpami.2025.3639593)
+
+
+|                      |                                                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Backbone**         | SwinUNETR                                                                                                   |
+| **Pre-training**     | `VoCo`, `contrastive learning` Volume contrastive learning with geometric context priors.                   |
+| **Training data**    | PreCT-160K **160,000** CT volumes                                                                           |
+| **Downstream tasks** | `segmentation`, `classification`, `regression`, `vision-language modeling` Evaluated on more than 50 tasks. |
+| **Modalities**       | `CT`                                                                                                        |
+| **Code**             | [github.com/Luffy03/Large-Scale-Medical](https://github.com/Luffy03/Large-Scale-Medical)                    |
+| **Dataset**          | [huggingface.co/datasets/Luffy503/PreCT-160K](https://huggingface.co/datasets/Luffy503/PreCT-160K)          |
+| **PDF name**         | `VoCo - Large-Scale 3D Medical Image Pre-Training With Geometric Context Priors.pdf`                        |
+
+
+
+
+
+
+**TAP-CT** — TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models *(arXiv 2025-12)*
+
+**[TAP-CT: 3D task-agnostic pretraining of computed tomography foundation models](https://arxiv.org/abs/2512.00872)**
+
+*arXiv* · 2025-12 · Preprint · [arXiv:2512.00872](https://arxiv.org/abs/2512.00872)
+
+
+|                      |                                                                                |
+| -------------------- | ------------------------------------------------------------------------------ |
+| **Backbone**         | 3D vision transformer                                                          |
+| **Pre-training**     | `DINOv2`                                                                       |
+| **Training data**    | **105,000** CT volumes                                                         |
+| **Downstream tasks** | `segmentation`, `classification` Task-agnostic 3D CT foundation-model suite.   |
+| **Modalities**       | `CT`                                                                           |
+| **Weights**          | [huggingface.co/fomofo/tap-ct-b-3d](https://huggingface.co/fomofo/tap-ct-b-3d) |
+| **PDF name**         | `TAP-CT - 3D Task-Agnostic Pretraining of CT Foundation Models.pdf`            |
+
+
+
+
+
+
+**AnyMC3D** — Revisiting 2D foundation models for scalable 3D medical image classification *(arXiv 2025-12)*
+
+**[Revisiting 2D foundation models for scalable 3D medical image classification](https://arxiv.org/abs/2512.12887)**
+
+*arXiv* · 2025-12 · Preprint · [arXiv:2512.12887](https://arxiv.org/abs/2512.12887)
+
+
+|                      |                                                                                        |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| **Backbone**         | DINOv2 and DINOv3 backbones with lightweight task plugins                              |
+| **Pre-training**     | `DINOv2`, `DINOv3`                                                                     |
+| **Training data**    | Numeric scale not recorded                                                             |
+| **Downstream tasks** | `classification` Scalable evaluation across 12 three-dimensional classification tasks. |
+| **Modalities**       | `CT`, `MRI`                                                                            |
+
+
+
+
+
+
+**Pillar-0** — Pillar-0: a new frontier for radiology foundation models *(arXiv 2025-11)*
+
+**[Pillar-0: a new frontier for radiology foundation models](https://arxiv.org/abs/2511.17803)**
+
+*arXiv* · 2025-11 · Preprint · [arXiv:2511.17803](https://arxiv.org/abs/2511.17803)
+
+
+|                      |                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------- |
+| **Backbone**         | Atlas                                                                            |
+| **Pre-training**     | `contrastive`, `vision-language` CLIP-like radiology pretraining.                |
+| **Training data**    | Abdomen-pelvis, chest and head CT plus breast MRI **155,292** volumes            |
+| **Downstream tasks** | `classification`, `prognosis` Best-performing model on 319 of 366 RATE findings. |
+| **Modalities**       | `CT`, `MRI`, `text`                                                              |
+| **Code**             | [github.com/YalaLab/pillar-pretrain](https://github.com/YalaLab/pillar-pretrain) |
+| **PDF name**         | `Pillar-0 - A New Frontier for Radiology Foundation Models.pdf`                  |
+
+
+
+
+
+
+**SPECTRE** — Scaling self-supervised and cross-modal pretraining for volumetric CT transformers *(CVPR 2026 2025-11)*
+
+**[Scaling self-supervised and cross-modal pretraining for volumetric CT transformers](https://arxiv.org/abs/2511.17209)**
+
+*CVPR 2026* · 2025-11 · Accepted · [arXiv:2511.17209](https://arxiv.org/abs/2511.17209)
+
+
+|                      |                                                                                |
+| -------------------- | ------------------------------------------------------------------------------ |
+| **Backbone**         | Local and global 3D vision transformers                                        |
+| **Pre-training**     | `DINOv3`, `SigLIP` Self-supervised and cross-modal pretraining.                |
+| **Training data**    | **230,000** CT volumes                                                         |
+| **Downstream tasks** | `classification`, `segmentation`, `retrieval` Scaling study for volumetric CT. |
+| **Modalities**       | `CT`, `text`                                                                   |
+| **Code**             | [github.com/cclaess/SPECTRE](https://github.com/cclaess/SPECTRE)               |
+
+
+
+
+
+
+**BrainFound** — Towards generalisable foundation models for brain MRI *(arXiv 2025-10)*
+
+**[Towards generalisable foundation models for brain MRI](https://arxiv.org/abs/2510.23415)**
+
+*arXiv* · 2025-10 · Preprint · [arXiv:2510.23415](https://arxiv.org/abs/2510.23415)
+
+
+|                      |                                                                                  |
+| -------------------- | -------------------------------------------------------------------------------- |
+| **Backbone**         | ViT-L                                                                            |
+| **Pre-training**     | `DINOv2`                                                                         |
+| **Training data**    | **10,000** MRI volumes                                                           |
+| **Downstream tasks** | `classification` Neurodegeneration classification and tumour grading.            |
+| **Modalities**       | `MRI`                                                                            |
+| **Code**             | [github.com/Moona-Mazher/BrainFound](https://github.com/Moona-Mazher/BrainFound) |
+
+
+
+
+
+
+**MRI-PTPCa** — An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer *(Nat. Cancer 2025-09)*
+
+**[An MRI–pathology foundation model for noninvasive diagnosis and grading of prostate cancer](https://www.nature.com/articles/s43018-025-01041-x)**
+
+*Nat. Cancer* · 2025-09 · Published · [doi:10.1038/s43018-025-01041-x](https://doi.org/10.1038/s43018-025-01041-x)
+
+
+|                      |                                                                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Backbone**         | CNN and vision transformer                                                                                                                                       |
+| **Pre-training**     | `BYOL`                                                                                                                                                           |
+| **Training data**    | Numeric scale not recorded                                                                                                                                       |
+| **Downstream tasks** | `classification`, `grading` Non-invasive prostate-cancer diagnosis and grading.                                                                                  |
+| **Modalities**       | `MRI`, `histopathology`                                                                                                                                          |
+| **Code**             | [github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer](https://github.com/StandWisdom/MRI-based-Predicted-Transformer-for-Prostate-cancer) |
+
+
+
+
+
+
+**Curia** — Curia: a multi-modal foundation model for radiology *(arXiv 2025-08)*
+
+**[Curia: a multi-modal foundation model for radiology](https://arxiv.org/abs/2509.06830)**
+
+*arXiv* · 2025-08 · Preprint · [arXiv:2509.06830](https://arxiv.org/abs/2509.06830)
+
+
+|                      |                                                                      |
+| -------------------- | -------------------------------------------------------------------- |
+| **Backbone**         | ViT-B                                                                |
+| **Pre-training**     | `DINOv2`                                                             |
+| **Training data**    | **164,000,000** CT and **64,000,000** MRI DICOM images               |
+| **Downstream tasks** | General-purpose multimodal radiology representation learning         |
+| **Modalities**       | `CT`, `MRI`                                                          |
+| **Code**             | [github.com/raidium-med/curia](https://github.com/raidium-med/curia) |
+
+
+
+
+
+
+**Percival** — A pan-organ vision–language model for generalizable 3D CT representations *(medRxiv 2025-07)*
+
+**[A pan-organ vision–language model for generalizable 3D CT representations](https://pmc.ncbi.nlm.nih.gov/articles/PMC12236870/)**
+
+*medRxiv* · 2025-07 · Preprint
+
+
+|                      |                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------- |
+| **Backbone**         | 3D DeiT                                                                           |
+| **Pre-training**     | `InfoNCE`, `contrastive` Vision-language pretraining with CT volumes and reports. |
+| **Training data**    | More than **403,000** CT volumes                                                  |
+| **Downstream tasks** | `retrieval`, `classification`, `prognosis` Pan-organ CT representation learning.  |
+| **Modalities**       | `CT`, `text`                                                                      |
+| **Code**             | [github.com/cams2b/percival](https://github.com/cams2b/percival)                  |
+
+
+
+
+
+
+**Spark3D** — Revisiting MAE pre-training for 3D medical image segmentation *(CVPR 2025 2025-04)*
+
+**[Revisiting MAE pre-training for 3D medical image segmentation](https://doi.org/10.1109/CVPR52734.2025.00489)**
+
+*CVPR 2025* · 2025-04 · Published · [doi:10.1109/CVPR52734.2025.00489](https://doi.org/10.1109/CVPR52734.2025.00489)
+
+
+|                      |                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| **Backbone**         | CNN U-Net                                                                                 |
+| **Pre-training**     | `MAE`                                                                                     |
+| **Training data**    | **44,000** MRI volumes from **9,000** patients                                            |
+| **Downstream tasks** | `segmentation` Masked-autoencoder pretraining for three-dimensional medical segmentation. |
+| **Modalities**       | `MRI`                                                                                     |
+| **Code**             | [github.com/MIC-DKFZ/nnssl](https://github.com/MIC-DKFZ/nnssl)                            |
+
+
+
+
+
+
+
+
+**CT-FM** — Vision foundation models for computed tomography *(arXiv 2025-01)*
+
+**[Vision foundation models for computed tomography](https://arxiv.org/abs/2501.09001)**
+
+*arXiv* · 2025-01 · Preprint · [arXiv:2501.09001](https://arxiv.org/abs/2501.09001)
+
+
+|                      |                                                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| **Backbone**         | SegResEncoder                                                                                                            |
+| **Pre-training**     | `SimCLR`                                                                                                                 |
+| **Training data**    | IDC corpus **148,000** CT volumes                                                                                        |
+| **Downstream tasks** | `segmentation`, `triage`, `retrieval` General-purpose computed-tomography representations.                               |
+| **Modalities**       | `CT`                                                                                                                     |
+| **Code**             | [github.com/project-lighter/CT-FM](https://github.com/project-lighter/CT-FM)                                             |
+| **Weights**          | [huggingface.co/project-lighter/ct_fm_feature_extractor](https://huggingface.co/project-lighter/ct_fm_feature_extractor) |
+| **PDF name**         | `CT-FM - Vision Foundation Models for Computed Tomography.pdf`                                                           |
+
+
+
+
+
+
+**3DINO** — A generalizable 3D framework and model for self-supervised learning in medical imaging *(arXiv 2025-01)*
+
+**[A generalizable 3D framework and model for self-supervised learning in medical imaging](https://arxiv.org/abs/2501.11755)**
+
+*arXiv* · 2025-01 · Preprint · [arXiv:2501.11755](https://arxiv.org/abs/2501.11755)
+
+
+|                      |                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| **Backbone**         | Vision transformer                                                                                |
+| **Pre-training**     | `3DINO`, `self-supervised`                                                                        |
+| **Training data**    | **1,300** patients                                                                                |
+| **Downstream tasks** | `classification`, `segmentation` Generalizable three-dimensional self-supervised medical imaging. |
+| **Modalities**       | `CT`, `MRI`                                                                                       |
+| **Code**             | [github.com/AICONSlab/3DINO](https://github.com/AICONSlab/3DINO)                                  |
+
+
+
+
+
+
+**BME-X** — A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks *(Nat. Biomed. Eng. 2024-12)*
+
+**[A foundation model for enhancing magnetic resonance images and downstream segmentation, registration and diagnostic tasks](https://www.nature.com/articles/s41551-024-01283-7)**
+
+*Nat. Biomed. Eng.* · 2024-12 · Published · [doi:10.1038/s41551-024-01283-7](https://doi.org/10.1038/s41551-024-01283-7)
+
+
+|                      |                                                                                                       |
+| -------------------- | ----------------------------------------------------------------------------------------------------- |
+| **Backbone**         | U-Net CNN                                                                                             |
+| **Pre-training**     | Not recorded                                                                                          |
+| **Training data**    | Numeric scale not recorded                                                                            |
+| **Downstream tasks** | `segmentation`, `registration`, `classification` MRI enhancement and downstream image-analysis tasks. |
+| **Modalities**       | `MRI`                                                                                                 |
+| **Code**             | [github.com/DBC-Lab/Brain_MRI_Enhancement](https://github.com/DBC-Lab/Brain_MRI_Enhancement)          |
+
+


### PR DESCRIPTION
## Summary
- Align the radiology catalogue with the pathology page format (date, model size, training data, pre-training).
- Fill published parameter counts and component notes; use `_not published_` / `_n/a_` when a size is unavailable.
- Rewrite non-volume training cells as `none (...)` or `not stated (...)`, matching pathology’s training-slides convention.

## Test plan
- [ ] Open `radiology.md` on GitHub and confirm the summary table renders (no leftover `—` cells).
- [ ] Spot-check a few model anchors from the table into the Details section.
- [ ] Confirm README still links to `radiology.md`.
