### PR TITLE
pathology: make the scan table columns informative, add Tissue Clocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A curated catalogue of biomedical artificial intelligence models and systems pub
 
 | Domain | Scope | Maintainer | Summary |
 | --- | --- | --- | ---: |
-| [Pathology](pathology.md) | Histopathology, whole-slide imaging and computational pathology | [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/leoyin1127)) | — |
+| [Pathology](pathology.md) | Histopathology, whole-slide imaging and computational pathology | [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/1nslyn)) | — |
 | [Radiology](radiology.md) | CT, MRI, PET, X-ray and fMRI | [Judy Lyu](https://github.com/judylyu) @ Sumin Kim |  |
 | [Biomedical Images — Other](biomedical_images.md) | Ultrasound, microscopy images, retinal imaging, OCT, dermatology, endoscopy and other imaging | @Terry Fu @Zaiyou He |  |
 | [Longitudinal Health Data](longitudinal.md) | Longitudinal EHR, physiological signals, wearables and temporal clinical records | Evan Su ([GitHub](https://github.com/HACKERALERT)) |  |

--- a/pathology.md
+++ b/pathology.md
@@ -12,21 +12,21 @@ Histopathology, whole-slide imaging and computational pathology.
 
 | Date | Model | Venue | Model size | Training slides | Pre-training | Downstream tasks |
 | --- | --- | --- | --- | --- | --- | --- |
-| 2026.07 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.35M | contrastive → dialogue next-token | detection, subtyping, grading +4 |
-| 2026.04 | [PRET](#model-pret-202604) | Nat. Cancer | _not published_ | none (training-free) | DINO ViT-S/8 encoder, then frozen | detection, subtyping, segmentation +1 |
-| 2026.03 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | _n/a_ | not stated (8.2K patients) | frozen CTransPath + CLAM/SlideGraph | biomarker prediction, mutation prediction, benchmarking |
-| 2026.02 | [Neuropath-AI](#model-neuropath-ai-202602) | Lancet Oncol. | _not published_ | 5.8K samples (not slides) | WSI → molecular inference → hierarchy | classification, mutation prediction, gene expression prediction |
-| 2026.02 | [KEEP](#model-keep-202602) | Cancer Cell | 414M | none (tile–text pairs) | knowledge-graph metric + contrastive | segmentation, detection, subtyping +2 |
-| 2026.02 | [CHAI](#model-chai-202602) | J. Clin. Oncol. | _not published_ | not stated (178 patients) | supervised histomorphologic screening | biomarker prediction, treatment response |
-| 2025.11 | [TITAN](#model-titan-202511) | Nat. Med. | 48.5M (slide enc.) | 336K | iBOT → CoCa (3 stages) | classification, subtyping, retrieval +2 |
-| 2025.11 | [SMMILe](#model-smmile-202511) | Nat. Cancer | 1.2M (MIL head) | 3.9K (cross-validated) | weakly supervised MIL, frozen encoder | classification, detection, subtyping +1 |
-| 2025.01 | [MUSK](#model-musk-202501) | Nature | 675M | 33K | BEiT-3 MIM → contrastive | retrieval, visual question answering, classification +4 |
-| 2024.09 | [CHIEF](#model-chief-202409) | Nature | _not published_ | 60.5K | CTransPath tiles → weakly supervised | classification, detection, subtyping +2 |
-| 2024.07 | [Virchow](#model-virchow-202407) | Nat. Med. | 632M | 1.5M | DINOv2 | detection, biomarker prediction, classification |
-| 2024.05 | [Prov-GigaPath](#model-prov-gigapath-202405) | Nature | 1B (tile enc.) | 171K | DINOv2 tiles → LongNet MAE slides | classification, subtyping, mutation prediction +1 |
-| 2024.03 | [UNI](#model-uni-202403) | Nat. Med. | 307M | 100K | DINOv2 | segmentation, detection, grading +3 |
-| 2024.03 | [CONCH](#model-conch-202403) | Nat. Med. | _not published_ | none (1.17M image–caption) | iBOT → CoCa | classification, retrieval, segmentation +1 |
-| 2023.08 | [PLIP](#model-plip-202308) | Nat. Med. | _not published_ | none (208K image–text) | CLIP contrastive fine-tune | classification, retrieval |
+| 202607 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.35M | contrastive → dialogue next-token | detection, subtyping, grading +4 |
+| 202604 | [PRET](#model-pret-202604) | Nat. Cancer | _not published_ | none (training-free) | DINO ViT-S/8 encoder, then frozen | detection, subtyping, segmentation +1 |
+| 202603 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | _n/a_ | not stated (8.2K patients) | frozen CTransPath + CLAM/SlideGraph | biomarker prediction, mutation prediction, benchmarking |
+| 202602 | [Neuropath-AI](#model-neuropath-ai-202602) | Lancet Oncol. | _not published_ | 5.8K samples (not slides) | WSI → molecular inference → hierarchy | classification, mutation prediction, gene expression prediction |
+| 202602 | [KEEP](#model-keep-202602) | Cancer Cell | 414M | none (tile–text pairs) | knowledge-graph metric + contrastive | segmentation, detection, subtyping +2 |
+| 202602 | [CHAI](#model-chai-202602) | J. Clin. Oncol. | _not published_ | not stated (178 patients) | supervised histomorphologic screening | biomarker prediction, treatment response |
+| 202511 | [TITAN](#model-titan-202511) | Nat. Med. | 48.5M (slide enc.) | 336K | iBOT → CoCa (3 stages) | classification, subtyping, retrieval +2 |
+| 202511 | [SMMILe](#model-smmile-202511) | Nat. Cancer | 1.2M (MIL head) | 3.9K (cross-validated) | weakly supervised MIL, frozen encoder | classification, detection, subtyping +1 |
+| 202501 | [MUSK](#model-musk-202501) | Nature | 675M | ~33K | BEiT-3 MIM → contrastive | retrieval, visual question answering, classification +4 |
+| 202409 | [CHIEF](#model-chief-202409) | Nature | _not published_ | 60.5K | CTransPath tiles → weakly supervised | classification, detection, subtyping +2 |
+| 202407 | [Virchow](#model-virchow-202407) | Nat. Med. | 632M | ~1.5M | DINOv2 | detection, biomarker prediction, classification |
+| 202405 | [Prov-GigaPath](#model-prov-gigapath-202405) | Nature | 1B (tile enc.) | 171K | DINOv2 tiles → LongNet MAE slides | classification, subtyping, mutation prediction +1 |
+| 202403 | [UNI](#model-uni-202403) | Nat. Med. | 307M | 100K | DINOv2 | segmentation, detection, grading +3 |
+| 202403 | [CONCH](#model-conch-202403) | Nat. Med. | _not published_ | none (1.17M image–caption) | iBOT → CoCa | classification, retrieval, segmentation +1 |
+| 202308 | [PLIP](#model-plip-202308) | Nat. Med. | _not published_ | none (208K image–text) | CLIP contrastive fine-tune | classification, retrieval |
 
 <sub><b>Model size</b> is the count the authors publish, with the component it covers in brackets — a slide encoder and a tile encoder are not comparable. <i>not published</i> means the access routes were worked and no author source states one; <i>n/a</i> means the paper does not introduce a model. <b>Training slides</b> counts whole slides used for training, so a model trained on tiles or image–text pairs shows what it used instead.</sub>
 

--- a/pathology.md
+++ b/pathology.md
@@ -1,32 +1,34 @@
 <!-- GENERATED FILE - DO NOT EDIT BY HAND -->
-<!-- Generated from data/pathology.yaml in https://github.com/leoyin1127/biomedical-ai-pipeline -->
+<!-- Generated from data/pathology.yaml in https://github.com/1nslyn/biomedical-ai-pipeline -->
 <!-- Edits made here are overwritten by the next build. -->
 
 # Pathology
 
 Histopathology, whole-slide imaging and computational pathology.
 
-**Maintainer:** [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/leoyin1127))
+**Maintainer:** [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/1nslyn))
 
 **15 entries** · [Back to index](README.md)
 
-| Date | Model | Venue | Model size | Training data | Pre-training | Downstream tasks |
+| Date | Model | Venue | Model size | Training slides | Pre-training | Downstream tasks |
 | --- | --- | --- | --- | --- | --- | --- |
-| 2026-07 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.4M WSI | contrastive, next-token prediction | detection, subtyping, grading +4 |
-| 2026-04 | [PRET](#model-pret-202604) | Nat. Cancer | — | 4.5K WSI (eval) | DINO, self-supervised | detection, subtyping, segmentation +1 |
-| 2026-03 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | — | 8.2K patients | self-supervised, weakly supervised | biomarker prediction, mutation prediction, benchmarking |
-| 2026-02 | [Neuropath-AI](#model-neuropath-ai-202602) | Lancet Oncol. | — | 5.8K training samples | self-supervised | classification, mutation prediction, gene expression prediction |
-| 2026-02 | [KEEP](#model-keep-202602) | Cancer Cell | 414M | 143K groups | contrastive | segmentation, detection, subtyping +2 |
-| 2026-02 | [CHAI](#model-chai-202602) | J. Clin. Oncol. | — | 477 patients | supervised | biomarker prediction, treatment response |
-| 2025-11 | [TITAN](#model-titan-202511) | Nat. Med. | 48.5M | 335.6K WSI | self-supervised, iBOT, CoCa +1 | classification, subtyping, retrieval +2 |
-| 2025-11 | [SMMILe](#model-smmile-202511) | Nat. Cancer | 1.2M | 3.9K WSI | weakly supervised | classification, detection, subtyping +1 |
-| 2025-01 | [MUSK](#model-musk-202501) | Nature | 675M | 33K WSI | MIM, contrastive | retrieval, visual question answering, classification +4 |
-| 2024-09 | [CHIEF](#model-chief-202409) | Nature | — | 60.5K WSI | self-supervised, weakly supervised | classification, detection, subtyping +2 |
-| 2024-07 | [Virchow](#model-virchow-202407) | Nat. Med. | 632M | 1.5M WSI | DINOv2 | detection, biomarker prediction, classification |
-| 2024-05 | [Prov-GigaPath](#model-prov-gigapath-202405) | Nature | 1B | 171.2K WSI | DINOv2, MAE | classification, subtyping, mutation prediction +1 |
-| 2024-03 | [UNI](#model-uni-202403) | Nat. Med. | 307M | 100.4K WSI | DINOv2 | segmentation, detection, grading +3 |
-| 2024-03 | [CONCH](#model-conch-202403) | Nat. Med. | — | 1.2M pairs | iBOT, CoCa | classification, retrieval, segmentation +1 |
-| 2023-08 | [PLIP](#model-plip-202308) | Nat. Med. | — | 208.4K pairs | CLIP, contrastive | classification, retrieval |
+| 2026.07 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.35M | contrastive → dialogue next-token | detection, subtyping, grading +4 |
+| 2026.04 | [PRET](#model-pret-202604) | Nat. Cancer | _not published_ | none (training-free) | DINO ViT-S/8 encoder, then frozen | detection, subtyping, segmentation +1 |
+| 2026.03 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | _n/a_ | not stated (8.2K patients) | frozen CTransPath + CLAM/SlideGraph | biomarker prediction, mutation prediction, benchmarking |
+| 2026.02 | [Neuropath-AI](#model-neuropath-ai-202602) | Lancet Oncol. | _not published_ | 5.8K samples (not slides) | WSI → molecular inference → hierarchy | classification, mutation prediction, gene expression prediction |
+| 2026.02 | [KEEP](#model-keep-202602) | Cancer Cell | 414M | none (tile–text pairs) | knowledge-graph metric + contrastive | segmentation, detection, subtyping +2 |
+| 2026.02 | [CHAI](#model-chai-202602) | J. Clin. Oncol. | _not published_ | not stated (178 patients) | supervised histomorphologic screening | biomarker prediction, treatment response |
+| 2025.11 | [TITAN](#model-titan-202511) | Nat. Med. | 48.5M (slide enc.) | 336K | iBOT → CoCa (3 stages) | classification, subtyping, retrieval +2 |
+| 2025.11 | [SMMILe](#model-smmile-202511) | Nat. Cancer | 1.2M (MIL head) | 3.9K (cross-validated) | weakly supervised MIL, frozen encoder | classification, detection, subtyping +1 |
+| 2025.01 | [MUSK](#model-musk-202501) | Nature | 675M | 33K | BEiT-3 MIM → contrastive | retrieval, visual question answering, classification +4 |
+| 2024.09 | [CHIEF](#model-chief-202409) | Nature | _not published_ | 60.5K | CTransPath tiles → weakly supervised | classification, detection, subtyping +2 |
+| 2024.07 | [Virchow](#model-virchow-202407) | Nat. Med. | 632M | 1.5M | DINOv2 | detection, biomarker prediction, classification |
+| 2024.05 | [Prov-GigaPath](#model-prov-gigapath-202405) | Nature | 1B (tile enc.) | 171K | DINOv2 tiles → LongNet MAE slides | classification, subtyping, mutation prediction +1 |
+| 2024.03 | [UNI](#model-uni-202403) | Nat. Med. | 307M | 100K | DINOv2 | segmentation, detection, grading +3 |
+| 2024.03 | [CONCH](#model-conch-202403) | Nat. Med. | _not published_ | none (1.17M image–caption) | iBOT → CoCa | classification, retrieval, segmentation +1 |
+| 2023.08 | [PLIP](#model-plip-202308) | Nat. Med. | _not published_ | none (208K image–text) | CLIP contrastive fine-tune | classification, retrieval |
+
+<sub><b>Model size</b> is the count the authors publish, with the component it covers in brackets — a slide encoder and a tile encoder are not comparable. <i>not published</i> means the access routes were worked and no author source states one; <i>n/a</i> means the paper does not introduce a model. <b>Training slides</b> counts whole slides used for training, so a model trained on tiles or image–text pairs shows what it used instead.</sub>
 
 ## Details
 
@@ -485,4 +487,4 @@ Click a model to expand its record.
 
 ---
 
-This page is generated. Add a paper by editing [`data/pathology.yaml`](https://github.com/leoyin1127/biomedical-ai-pipeline/blob/main/data/pathology.yaml) in the [pipeline repository](https://github.com/leoyin1127/biomedical-ai-pipeline) and rebuilding — edits made here are overwritten. The schema and house rules are in [CONTRIBUTING.md](https://github.com/leoyin1127/biomedical-ai-pipeline/blob/main/CONTRIBUTING.md).
+This page is generated. Add a paper by editing [`data/pathology.yaml`](https://github.com/1nslyn/biomedical-ai-pipeline/blob/main/data/pathology.yaml) in the [pipeline repository](https://github.com/1nslyn/biomedical-ai-pipeline) and rebuilding — edits made here are overwritten. The schema and house rules are in [CONTRIBUTING.md](https://github.com/1nslyn/biomedical-ai-pipeline/blob/main/CONTRIBUTING.md).

--- a/pathology.md
+++ b/pathology.md
@@ -41,7 +41,7 @@ Click a model to expand its record.
 
 **[Histological aging signatures for monitoring tissue-specific aging and disease](https://www.nature.com/articles/s41591-026-04566-5)**
 
-*Nat. Med.* · 2026-08 · Ernesto Abila & André F. Rendeiro · [doi:10.1038/s41591-026-04566-5](https://doi.org/10.1038/s41591-026-04566-5)
+*Nat. Med.* · 2026-08 · [Ernesto Abila](https://scholar.google.com/citations?user=EaXz-AIAAAAJ&hl=en) & [André F. Rendeiro](https://scholar.google.at/citations?user=lj17pqEAAAAJ&hl=en) · [doi:10.1038/s41591-026-04566-5](https://doi.org/10.1038/s41591-026-04566-5)
 
 | | |
 | --- | --- |
@@ -159,7 +159,7 @@ Click a model to expand its record.
 
 **[Classification accuracy of a hierarchical molecular inference-based deep-learning system for CNS tumour diagnosis: a multi-institutional, retrospective study](https://www.thelancet.com/journals/lanonc/article/PIIS1470-2045%2825%2900661-8/abstract)**
 
-*Lancet Oncol.* · 2026-02 · H. Lalchungnunga & Kenneth Aldape · [doi:10.1016/S1470-2045(25)00661-8](https://doi.org/10.1016/S1470-2045%2825%2900661-8)
+*Lancet Oncol.* · 2026-02 · H. Lalchungnunga & [Kenneth Aldape](https://scholar.google.com/citations?user=vZM9E_AAAAAJ&hl=en) · [doi:10.1016/S1470-2045(25)00661-8](https://doi.org/10.1016/S1470-2045%2825%2900661-8)
 
 | | |
 | --- | --- |

--- a/pathology.md
+++ b/pathology.md
@@ -8,10 +8,11 @@ Histopathology, whole-slide imaging and computational pathology.
 
 **Maintainer:** [Leo Yin](https://shuolinyin.com) ([GitHub](https://github.com/1nslyn))
 
-**15 entries** · [Back to index](README.md)
+**16 entries** · [Back to index](README.md)
 
 | Date | Model | Venue | Model size | Training slides | Pre-training | Downstream tasks |
 | --- | --- | --- | --- | --- | --- | --- |
+| 202608 | [Tissue Clocks](#model-tissue-clocks-202608) | Nat. Med. | _not published_ | 25.7K (cross-validated) | ImageNet ConvNeXt → tissue-class tuning | regression, risk prediction, benchmarking |
 | 202607 | [PRISM2](#model-prism2-202607) | Nat. Med. | 4.6B | 2.35M | contrastive → dialogue next-token | detection, subtyping, grading +4 |
 | 202604 | [PRET](#model-pret-202604) | Nat. Cancer | _not published_ | none (training-free) | DINO ViT-S/8 encoder, then frozen | detection, subtyping, segmentation +1 |
 | 202603 | [HistBiases](#model-histbiases-202603) | Nat. Biomed. Eng. | _n/a_ | not stated (8.2K patients) | frozen CTransPath + CLAM/SlideGraph | biomarker prediction, mutation prediction, benchmarking |
@@ -33,6 +34,34 @@ Histopathology, whole-slide imaging and computational pathology.
 ## Details
 
 Click a model to expand its record.
+
+<a id="model-tissue-clocks-202608"></a>
+<details>
+<summary><b>Tissue Clocks</b> — Histological aging signatures for monitoring tissue-specific aging and disease <i>(Nat. Med. 2026-08)</i></summary>
+
+**[Histological aging signatures for monitoring tissue-specific aging and disease](https://www.nature.com/articles/s41591-026-04566-5)**
+
+*Nat. Med.* · 2026-08 · Ernesto Abila & André F. Rendeiro · [doi:10.1038/s41591-026-04566-5](https://doi.org/10.1038/s41591-026-04566-5)
+
+| | |
+| --- | --- |
+| **Backbone** | ImageNet-pretrained ConvNeXt base, fine-tuned as a tissue-type classifier and then frozen as a feature extractor; a slide is represented by its mean tile embedding at three magnifications, and regularised linear or ensemble regressors map that to age |
+| **Pre-training** | `supervised`<br>Supervised transfer learning rather than pathology-specific pretraining. ImageNet architectures (AlexNet, VGG16, ResNet50, ResNet152, ConvNeXt tiny and ConvNeXt base) were fine-tuned to classify tissue type on a dataset balanced across tissue, age bracket and sex -- one epoch with the backbone frozen, then up to 100 epochs of fine-tuning -- and the fine-tuned ConvNeXt base was carried forward. Tiles of 224, 448 and 896 pixels at roughly 0.5 microns per pixel are embedded and averaged per slide, and the age regressor is fitted on those features. |
+| **Training data** | GTEx post-mortem H&E whole-slide images spanning 40 tissue types and 29 organs, paired with the cohort's transcriptomic, methylation and phenotypic records. Validated on separate brain, lung and skin cohorts.<br>**25,712** WSI · **983** individuals · **40** tissue types · **480,000,000** image tiles |
+| **Downstream tasks** | `regression`, `risk prediction`, `benchmarking`<br>Predicts chronological age from tissue morphology and treats the residual -- the "age gap" -- as a measure of biological aging; relates tissue-specific age acceleration to telomere length, subclinical pathology, comorbidities and lifestyle factors; predicts tissue-specific age gaps from blood gene expression via ridge regression; and benchmarks 7 classical vision models and 18 pathology foundation models as feature extractors for the same task. |
+| **Modalities** | `histopathology`, `transcriptomics` |
+| **Code** | [github.com/rendeirolab/tissue-clocks](https://github.com/rendeirolab/tissue-clocks) |
+| **License** | PolyForm-Noncommercial-1.0.0 |
+
+**Reported performance**
+
+| Benchmark | Metric | Value | Note |
+| --- | --- | --- | --- |
+| GTEx, biological age from histology (cross-validated, all tissues) | mean absolute error | 4.88 years | coefficient of determination 0.69 |
+| Feature-extractor comparison, 7 classical vision and 18 pathology foundation models | mean MAE across organs and models | 8.67 vs 5.74 | classical ImageNet models 8.67, pathology foundation models 5.74, against 4.88 for this paper's fine-tuned model. The authors caution that some foundation models were pretrained on data that includes GTEx, which may flatter them here. |
+| External cohorts, GTEx-trained clocks applied unchanged | Pearson correlation with chronological age | 0.56 / 0.76 / 0.46 | brain (n = 70), lung (n = 40) and skin (n = 185) |
+
+</details>
 
 <a id="model-prism2-202607"></a>
 <details>


### PR DESCRIPTION
Replaces #4, which conflicted. The conflict was entirely in `README.md` — six other maintainers edited it while #4 sat open. **Nothing on main has touched `pathology.md`**, so this rebases cleanly onto current main.

Same fifteen entries, same layout. Four columns of the scan table were rendering values that did not distinguish the rows they sat in, and one of them was wrong.

## Pre-training: name the recipe, not the paradigm

`self-supervised` was the value on nearly every row. It is accurate and it tells a reader nothing — it is equally the answer for Virchow, UNI, TITAN, CHIEF, PRET and Neuropath-AI.

| | Was | Now |
| --- | --- | --- |
| Virchow, UNI | `DINOv2` | `DINOv2` |
| TITAN | `self-supervised, iBOT, CoCa +1` | `iBOT → CoCa (3 stages)` |
| MUSK | `MIM, contrastive` | `BEiT-3 MIM → contrastive` |
| Prov-GigaPath | `DINOv2, MAE` | `DINOv2 tiles → LongNet MAE slides` |
| PRISM2 | `contrastive, next-token prediction` | `contrastive → dialogue next-token` |
| Neuropath-AI | `self-supervised` | `WSI → molecular inference → hierarchy` |
| CHIEF | `self-supervised, weakly supervised` | `CTransPath tiles → weakly supervised` |
| HistBiases | `self-supervised, weakly supervised` | `frozen CTransPath + CLAM/SlideGraph` |
| CHAI | `supervised` | `supervised histomorphologic screening` |

The `pretraining` vocabulary itself is unchanged. It is built for filtering, so coarse buckets are right there — they just should not have been the column.

## Model size: say what the count covers, and why it is missing

Seven of fifteen cells were a bare em dash, which reads as *nobody looked*. For six the access routes were worked and the authors publish no count; the seventh introduces no model. Those are different facts:

- **_not published_** — routes worked, no author source states one (PRET, Neuropath-AI, CHAI, CHIEF, CONCH, PLIP)
- **_n/a_** — the paper introduces no model (HistBiases)

The eight real counts carry their scope where it matters. `48.5M` beside `632M` reads as a 13× difference; it is a slide encoder beside a tile encoder.

| | Was | Now |
| --- | --- | --- |
| TITAN | `48.5M` | `48.5M (slide enc.)` |
| SMMILe | `1.2M` | `1.2M (MIL head)` |
| Prov-GigaPath | `1B` | `1B (tile enc.)` |

**Six counts still need a human** — this is the manual-intervention list, and two of them are cheap:

| Model | What it needs |
| --- | --- |
| CONCH | `MahmoodLab/CONCH` on HuggingFace is gated (401). Click through the access request and the checkpoint gives it. |
| PLIP | `vinid/plip` is public but ships `pytorch_model.bin`, so HuggingFace publishes no computed total. Loading it locally resolves it. |
| PRET, CHAI | Methods are paywalled (Nat. Cancer; ascopubs answers 403) — institutional access. |
| Neuropath-AI | Lancet full text is behind Cloudflare. |
| CHIEF | No author source anywhere. Realistically an email to the authors. |

## Training data → training slides

This is the column that was actually wrong. It picked a number out of `data.scale` by key priority, and `data.scale` counts different things in different records. PRET is training-free and its 4,484 slides are its benchmark; SMMILe's 3,850 are its whole cross-validated evaluation. Both rendered as training corpora.

| | Was | Now |
| --- | --- | --- |
| PRET | `4.5K WSI (eval)` | `none (training-free)` |
| SMMILe | `3.9K WSI` | `3.9K (cross-validated)` |
| KEEP | `143K groups` | `none (tile–text pairs)` |
| CONCH | `1.2M pairs` | `none (1.17M image–caption)` |
| Neuropath-AI | `5.8K training samples` | `5.8K samples (not slides)` |
| HistBiases | `8.2K patients` | `not stated (8.2K patients)` |
| CHAI | `477 patients` | `not stated (178 patients)` |
| Virchow, TITAN, UNI | `1.5M WSI`, `335.6K WSI`, `100.4K WSI` | `~1.5M`, `336K`, `100K` |

CHAI is worth calling out: 477 is the full cohort, of which 178 are development and 299 validation. The old column labelled the whole cohort as training data.

## Also in this PR: one new paper

**Tissue Clocks** — *Histological aging signatures for monitoring tissue-specific aging and disease* (Nat. Med., 2026-08, `10.1038/s41591-026-04566-5`). Routed to pathology by rule 1 of `add-paper.md`: built for one imaging modality, so that page wins, even though the work also uses blood transcriptomics. Open access, so every field is read from the article rather than the abstract.

ImageNet ConvNeXt base fine-tuned as a tissue-type classifier, then frozen as a feature extractor over ~480 million tiles at three magnifications; regularised regressors map slide features to age, and the residual is the "age gap". MAE 4.88 years across all tissues (R² 0.69), and Pearson r 0.56 / 0.76 / 0.46 on external brain, lung and skin cohorts.

`params` is `not published` — the full text states no count (its only two uses of "parameter" are PCA and ridge hyperparameters), no checkpoint is released, and the repo ships analysis code. Not inferred from "ConvNeXt base". Its licence was read from the repository's `LICENSE` directly (PolyForm Noncommercial 1.0.0), since the GitHub API reports `NOASSERTION` for it.

Its YAML record is the paired PR 1nslyn/biomedical-ai-pipeline#3, whose CI validates against **this** branch.

## Dates

`2026-07` → `202607`. Any separator is a line-break opportunity, so the narrowest column wrapped onto two lines; dropping it keeps the cell on one line and leaves the column sorting the way it reads.

## Verification

Every scan-table figure was checked against a source, not against the record it came from:

- **TITAN** — *"pretrained using 335,645 whole-slide images"* (PMC12618242). The three-stage recipe is confirmed too: iBOT on Mass-340K, CoCa on 423,122 ROI–caption pairs, then 182,862 slide–report pairs.
- **MUSK** — *"nearly 33,000 digitized H&E-stained WSIs from 11,577 patients"* (PMC12295649). Approximate in the source, so the cell reads `~33K`.
- **Virchow** — *"approximately 1.5 million H&E stained WSIs"*, likewise `~1.5M`.
- **KEEP** — *"reorganize millions of pathology image-text pairs into 143,000 semantically structured groups"* (arXiv 2412.13126), confirming the model never trains on a whole slide.

Beyond the spot checks, every `training_slides` figure was machine-checked against its `data.scale` key and every `pretraining_short` token against the record's own `pretraining_detail` and `backbone`. All fifteen trace; no unsourced value survives. The four labels the checker flagged (`CLAM/SlideGraph`, `hierarchy`, `knowledge-graph`, `screening`) were word-form differences — each term appears in its record's prose.

## Review notes

- The three new fields (`pretraining_short`, `params_scope`, `training_slides`) are **summaries of data already in each record** — the pre-training label condenses `pretraining_detail`, the slide count comes from `data.scale`. **No sourced value was edited and no new claim about any paper is introduced**; where a cell shows a different number than before it is a different field of the same record, not a revised figure.
- `validate.py` enforces the invariants: `params_status` is required exactly when `params` is null and rejected when it is not, `params_scope` is rejected on an empty count, and each cell has a length limit so the table cannot silently start wrapping again.
- A legend under the table explains *not published* / *n/a* and the scope brackets, and renders only on pages that use them.
- `README.md` changes by one line: the GitHub handle in the Pathology row, following the `leoyin1127` → `1nslyn` account rename. The old link resolves only via GitHub's rename redirect, which breaks if anyone claims the old name. Column layout and the other eight rows are byte-identical to main.

Generated from `data/pathology.yaml` in [1nslyn/biomedical-ai-pipeline](https://github.com/1nslyn/biomedical-ai-pipeline). `pathology.md` is a build artifact — edits here are overwritten; changes belong in the YAML.
